### PR TITLE
chore: add a test aggregation workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
   schedule:
     interval: daily
   ignore:
-  - dependency-name: "github.com/fatih/color "
-    versions: ">=1.16.0"
+  - dependency-name: "github.com/fatih/color"
 - package-ecosystem: github-actions
   directory: /
   schedule:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,86 @@
+name: Checks
+run-name: Checks, branch:${{ github.ref_name }}, triggered by @${{ github.actor }}
+
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - 'main'
+      - 'release/[0-9]+.[0-9]+.x'
+    tags:
+      - '**'
+  workflow_dispatch: {}
+
+jobs:
+  up-to-date:
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.up-to-date.outputs.status }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if PR is up to date, if it is skip workflows for this ref
+        id: 'up-to-date'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+        uses: Kong/public-shared-actions/pr-previews/up-to-date@v1.13.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # This job is used to check if the secrets are available. If they are not, we'll skip jobs that require them.
+  should-run-with-secrets:
+    runs-on: ubuntu-latest
+    needs:
+    - up-to-date
+    if: needs.up-to-date.outputs.status != 'true'
+    outputs:
+      result: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Check if secrets are available
+        id: check
+        run: |
+          if [ "${{ secrets.PULP_PASSWORD }}" == "" ]; then
+            echo "result=false" >> $GITHUB_OUTPUT
+          else
+            echo "result=true" >> $GITHUB_OUTPUT
+          fi
+
+  enterprise-integration-tests:
+    needs:
+    - should-run-with-secrets
+    - up-to-date
+    if: needs.should-run-with-secrets.outputs.result == 'true' && needs.up-to-date.outputs.status != 'true'
+    uses: ./.github/workflows/integration-enterprise.yaml
+    secrets: inherit
+
+  integration-tests:
+    needs:
+    - up-to-date
+    if: needs.up-to-date.outputs.status != 'true'
+    uses: ./.github/workflows/integration.yaml
+    secrets: inherit
+
+  # We need this step to fail the workflow if any of the previous steps failed or were cancelled.
+  # It allows to use this particular job as a required check for PRs.
+  # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
+  passed:
+    runs-on: ubuntu-latest
+    needs:
+      - up-to-date
+      - integration-tests
+      - enterprise-integration-tests
+    if: always()
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Some jobs failed or were cancelled."
+          exit 1

--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -1,11 +1,5 @@
 name: Enterprise Integration Test
 
-concurrency:
-  # Run only for most recent commit in PRs but for all tags and commits on main
-  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
-  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
-  cancel-in-progress: true
-
 on:
   workflow_call:
 

--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -7,10 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-    - main
-  pull_request: {}
+  workflow_call:
 
 jobs:
   integration:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,11 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-    - main
-  pull_request:
-    - *
+  workflow_call:
 
 jobs:
   integration:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,11 +1,5 @@
 name: Integration Test
 
-concurrency:
-  # Run only for most recent commit in PRs but for all tags and commits on main
-  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
-  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
-  cancel-in-progress: true
-
 on:
   workflow_call:
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/alecthomas/jsonschema v0.0.0-20191017121752-4bb6e3fae4f2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/fatih/color v1.16.0
+	github.com/fatih/color v1.15.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=


### PR DESCRIPTION
Re https://github.com/Kong/go-database-reconciler/pull/21#issuecomment-1836186240 why things merged without passing tests, well, we simply have no required tests! We have a require status checks branch protection rule with no required status checks configured, same as deck did. I'm not sure if anything was preventing merges with failures in the past.

This cannibalizes a similar [KIC workflow](https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/checks.yaml) that aggregates required test workflows into a single `passed` status. Note that we still need to add this to the branch protection rules after for it to have effect.