### PR TITLE
Add Kong 3.6 to integration tests

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -23,6 +23,7 @@ jobs:
         - 'kong/kong-gateway:3.3'
         - 'kong/kong-gateway:3.4'
         - 'kong/kong-gateway:3.5'
+        - 'kong/kong-gateway:3.6'
         - 'kong/kong-gateway-dev:latest'
     env:
       KONG_ANONYMOUS_REPORTS: "off"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,6 +25,7 @@ jobs:
         - 'kong:3.3'
         - 'kong:3.4'
         - 'kong:3.5'
+        - 'kong:3.6'
         - 'kong/kong:master-alpine'
     env:
       KONG_ANONYMOUS_REPORTS: "off"


### PR DESCRIPTION
### Summary

Add Kong 3.6 to integration tests: `kong:3.6` for Kong OSS and `kong/kong-gateway:3.6` for Kong EE.

Review: remove some OLD versions like Kong 1.x as they are not supported?

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Part of #62.

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
