### PR TITLE
chore: fix CI and update Kong images

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -23,6 +23,7 @@ jobs:
         - 'kong/kong-gateway:3.3'
         - 'kong/kong-gateway:3.4'
         - 'kong/kong-gateway:3.5'
+        - 'kong/kong-gateway:3.6'
         - 'kong/kong-gateway-dev:latest'
     env:
       KONG_ANONYMOUS_REPORTS: "off"
@@ -33,9 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
+        uses: actions/setup-go@v5
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,8 @@ jobs:
         - 'kong:3.3'
         - 'kong:3.4'
         - 'kong:3.5'
-        - 'kong/kong:master-alpine'
+        - 'kong:3.6'
+        - 'kong/kong:master'
     env:
       KONG_ANONYMOUS_REPORTS: "off"
       KONG_IMAGE: ${{ matrix.kong_image }}
@@ -34,9 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
+        uses: actions/setup-go@v5
       - name: Setup Kong
         run: make setup-kong
       - name: Run integration tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,8 @@ on:
     branches:
     - main
   pull_request:
-    - *
+    branches:
+    - '**'
 
 jobs:
   test:
@@ -20,9 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
+        uses: actions/setup-go@v5
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
       - name: Run tests with Coverage


### PR DESCRIPTION
### Summary

Fix CI by using proper `branches` specifier in `.github/workflows/test.yaml` and also update kong images and bump `setup-go` to v5
