### PR TITLE
ci: fix `make clean` and refactor

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -1,0 +1,82 @@
+set -euo pipefail
+
+readonly NETWORK_NAME=go-db-reconciler-test
+readonly DOCKER_LABEL=com.konghq.test.go-database-reconciler=1
+readonly KONG_PG_HOST=kong-postgres
+readonly KONG_PG_USER=kong
+readonly KONG_PG_DATABASE=kong
+readonly KONG_PG_PASSWORD=kong
+readonly KONG_PG_PORT=5432
+
+readonly DOCKER_ARGS=(
+    --label "$DOCKER_LABEL"
+    --network "$NETWORK_NAME"
+    -e "KONG_DATABASE=postgres"
+    -e "KONG_PG_HOST=$KONG_PG_HOST"
+    -e "KONG_PG_PORT=$KONG_PG_PORT"
+    -e "KONG_PG_USER=$KONG_PG_USER"
+    -e "KONG_PG_DATABASE=$KONG_PG_DATABASE"
+    -e "KONG_PG_PASSWORD=$KONG_PG_PASSWORD"
+    -e "KONG_PROXY_ACCESS_LOG=/dev/stdout"
+    -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout"
+    -e "KONG_PROXY_ERROR_LOG=/dev/stderr"
+    -e "KONG_ADMIN_ERROR_LOG=/dev/stderr"
+    -e "KONG_LOG_LEVEL=${KONG_LOG_LEVEL:-notice}"
+)
+
+waitContainer() {
+    local -r container=$1
+    shift
+
+    for _ in {1..100}; do
+        echo "waiting for $container"
+        if docker exec \
+            --user root \
+            "$container" \
+            "$@"
+        then
+            return
+        fi
+        sleep 0.2
+    done
+
+    echo "FATAL: failed waiting for $container"
+    exit 1
+}
+
+initNetwork() {
+    docker network create \
+        --label "$DOCKER_LABEL" \
+        "$NETWORK_NAME"
+}
+
+initDb() {
+    docker run \
+        --rm \
+        --detach \
+        --name "$KONG_PG_HOST" \
+        --label "$DOCKER_LABEL" \
+        --network $NETWORK_NAME \
+        -p "${KONG_PG_PORT}:${KONG_PG_PORT}" \
+        -e "POSTGRES_USER=$KONG_PG_USER" \
+        -e "POSTGRES_DB=$KONG_PG_DATABASE" \
+        -e "POSTGRES_PASSWORD=$KONG_PG_PASSWORD" \
+        postgres:9.6
+
+    waitContainer "$KONG_PG_HOST" pg_isready
+}
+
+initMigrations() {
+    local -r image=$1
+    shift
+
+    docker run \
+        --rm \
+        "${DOCKER_ARGS[@]}" \
+        "$@" \
+        "$image" \
+            kong migrations bootstrap \
+                --yes \
+                --force \
+                --db-timeout 30
+}

--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -1,65 +1,27 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-KONG_IMAGE=${KONG_IMAGE}
-NETWORK_NAME=deck-test
+source ./.ci/lib.sh
 
-PG_CONTAINER_NAME=pg
-DATABASE_USER=kong
-DATABASE_NAME=kong
-KONG_DB_PASSWORD=kong
-KONG_PG_HOST=pg
+KONG_IMAGE=${KONG_IMAGE?KONG_IMAGE is required to be set}
+
+initNetwork
+initDb
+initMigrations "$KONG_IMAGE"
 
 GATEWAY_CONTAINER_NAME=kong
 
-waitContainer() {
-  for try in {1..100}; do
-    echo "waiting for $1"
-    docker exec --user root $2 $3 && break;
-    sleep 0.2
-  done
-}
-
-# create docker network
-docker network create $NETWORK_NAME
-
-# Start a PostgreSQL container
-docker run --rm -d --name $PG_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -p 5432:5432 \
-  -e "POSTGRES_USER=$DATABASE_USER" \
-  -e "POSTGRES_DB=$DATABASE_NAME" \
-  -e "POSTGRES_PASSWORD=$KONG_DB_PASSWORD" \
-  postgres:9.6
-
-waitContainer "PostGres" $PG_CONTAINER_NAME pg_isready
-
-# Prepare the Kong database
-docker run --rm --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_PASSWORD=$KONG_DB_PASSWORD" \
-  $KONG_IMAGE kong migrations bootstrap
-
 # Start Kong Gateway
-docker run -d --name $GATEWAY_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_USER=$DATABASE_USER" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
-  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
-  -p 8000:8000 \
-  -p 8443:8443 \
-  -p 127.0.0.1:8001:8001 \
-  -p 127.0.0.1:8444:8444 \
-  $KONG_IMAGE
+docker run \
+    --detach \
+    --name $GATEWAY_CONTAINER_NAME \
+    "${DOCKER_ARGS[@]}" \
+    -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+    -p 8000:8000 \
+    -p 8443:8443 \
+    -p 127.0.0.1:8001:8001 \
+    -p 127.0.0.1:8444:8444 \
+    "$KONG_IMAGE"
 
-waitContainer "Kong" $GATEWAY_CONTAINER_NAME "kong health"
+waitContainer "$GATEWAY_CONTAINER_NAME" kong health

--- a/.ci/setup_kong_ee.sh
+++ b/.ci/setup_kong_ee.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
+
+source ./.ci/lib.sh
 
 MY_SECRET_CERT='''-----BEGIN CERTIFICATE-----
 MIIEczCCAlugAwIBAgIJAMw8/GAiHIFBMA0GCSqGSIb3DQEBCwUAMDYxCzAJBgNV
@@ -57,73 +59,33 @@ KlBs7O9y+fc4AIIn6JD+9tymB1TWEn1B+3Vv6jmtzbztuCQTbJ6rTT3CFcE6TdyJ
 8rYuG3/p2VkcG29TWbQARtj5ewv9p5QNfaecUzN+tps89YzawWQBanwI
 -----END RSA PRIVATE KEY-----'''
 
-KONG_IMAGE=${KONG_IMAGE}
-NETWORK_NAME=deck-test
+KONG_IMAGE=${KONG_IMAGE?KONG_IMAGE is required to be set}
+GATEWAY_CONTAINER_NAME=kong-enterprise
 
-PG_CONTAINER_NAME=pg
-DATABASE_USER=kong
-DATABASE_NAME=kong
-KONG_DB_PASSWORD=kong
-KONG_PG_HOST=pg
-
-GATEWAY_CONTAINER_NAME=kong
-
-# create docker network
-docker network create $NETWORK_NAME
-
-waitContainer() {
-  for try in {1..100}; do
-    echo "waiting for $1"
-    docker exec --user root $2 $3 && break;
-    sleep 0.2
-  done
-}
-
-# Start a PostgreSQL container
-docker run --rm -d --name $PG_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -p 5432:5432 \
-  -e "POSTGRES_USER=$DATABASE_USER" \
-  -e "POSTGRES_DB=$DATABASE_NAME" \
-  -e "POSTGRES_PASSWORD=$KONG_DB_PASSWORD" \
-  postgres:9.6
-
-waitContainer "PostGres" $PG_CONTAINER_NAME pg_isready
-
-# Prepare the Kong database
-docker run --rm --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
-  $KONG_IMAGE kong migrations bootstrap
+initNetwork
+initDb
+initMigrations "$KONG_IMAGE" \
+    -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA"
 
 # Start Kong Gateway EE
-docker run -d --name $GATEWAY_CONTAINER_NAME \
-  --network=$NETWORK_NAME \
-  -e "KONG_DATABASE=postgres" \
-  -e "KONG_PG_HOST=$KONG_PG_HOST" \
-  -e "KONG_PG_USER=$DATABASE_USER" \
-  -e "KONG_PG_PASSWORD=$KONG_DB_PASSWORD" \
-  -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
-  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
-  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
-  -e "KONG_PORTAL_GUI_URI=127.0.0.1:8003" \
-  -e "KONG_ADMIN_GUI_URL=http://127.0.0.1:8002" \
-  -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
-  -e "MY_SECRET_CERT=$MY_SECRET_CERT" \
-  -e "MY_SECRET_KEY=$MY_SECRET_KEY" \
-  -p 8000:8000 \
-  -p 8443:8443 \
-  -p 8001:8001 \
-  -p 8444:8444 \
-  -p 8002:8002 \
-  -p 8445:8445 \
-  -p 8003:8003 \
-  -p 8004:8004 \
-  $KONG_IMAGE
+docker run \
+    --detach \
+    "${DOCKER_ARGS[@]}" \
+    --name $GATEWAY_CONTAINER_NAME \
+    -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
+    -e "KONG_PORTAL_GUI_URI=127.0.0.1:8003" \
+    -e "KONG_ADMIN_GUI_URL=http://127.0.0.1:8002" \
+    -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
+    -e "MY_SECRET_CERT=$MY_SECRET_CERT" \
+    -e "MY_SECRET_KEY=$MY_SECRET_KEY" \
+    -p 8000:8000 \
+    -p 8443:8443 \
+    -p 8001:8001 \
+    -p 8444:8444 \
+    -p 8002:8002 \
+    -p 8445:8445 \
+    -p 8003:8003 \
+    -p 8004:8004 \
+    "$KONG_IMAGE"
 
-waitContainer "Kong" $GATEWAY_CONTAINER_NAME "kong health"
+waitContainer "$GATEWAY_CONTAINER_NAME" kong health

--- a/.ci/setup_kong_ee.sh
+++ b/.ci/setup_kong_ee.sh
@@ -64,20 +64,20 @@ GATEWAY_CONTAINER_NAME=kong-enterprise
 
 initNetwork
 initDb
-initMigrations "$KONG_IMAGE" \
-    -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA"
+initMigrations "${KONG_IMAGE}" \
+    -e "KONG_LICENSE_DATA=${KONG_LICENSE_DATA}"
 
 # Start Kong Gateway EE
 docker run \
     --detach \
     "${DOCKER_ARGS[@]}" \
-    --name $GATEWAY_CONTAINER_NAME \
+    --name ${GATEWAY_CONTAINER_NAME} \
     -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
     -e "KONG_PORTAL_GUI_URI=127.0.0.1:8003" \
     -e "KONG_ADMIN_GUI_URL=http://127.0.0.1:8002" \
-    -e "KONG_LICENSE_DATA=$KONG_LICENSE_DATA" \
-    -e "MY_SECRET_CERT=$MY_SECRET_CERT" \
-    -e "MY_SECRET_KEY=$MY_SECRET_KEY" \
+    -e "KONG_LICENSE_DATA=${KONG_LICENSE_DATA}" \
+    -e "MY_SECRET_CERT=${MY_SECRET_CERT}" \
+    -e "MY_SECRET_KEY=${MY_SECRET_KEY}" \
     -p 8000:8000 \
     -p 8443:8443 \
     -p 8001:8001 \
@@ -86,6 +86,6 @@ docker run \
     -p 8445:8445 \
     -p 8003:8003 \
     -p 8004:8004 \
-    "$KONG_IMAGE"
+    "${KONG_IMAGE}"
 
-waitContainer "$GATEWAY_CONTAINER_NAME" kong health
+waitContainer "${GATEWAY_CONTAINER_NAME}" kong health


### PR DESCRIPTION
The integration cleanup script (`.ci/clean_kong.sh`) had a couple warts:

* the `--filter Name=<name>` arg performs substring matching, so if you have an unrelated container named `kong-foo` running, it would enter the wrong branch and throw an error
* manually tracking docker resources for cleanup gets pretty tedious

I updated it to filter resources based on a known docker label instead.

This involved touching a few different files to add docker labels and such, so I wound up DRY-ing up some of the CI setup scripts along the way.