### PR TITLE
fix: improve lookup of consumer-groups' consumers

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -53,3 +53,4 @@ jobs:
         env:
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         run: make test-integration
+        continue-on-error: ${{ matrix.kong_image == 'kong/kong-gateway-dev:latest' }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -40,3 +40,4 @@ jobs:
         run: make setup-kong
       - name: Run integration tests
         run: make test-integration
+        continue-on-error: ${{ matrix.kong_image == 'kong/kong:master' }}


### PR DESCRIPTION
This commit makes lookups for consumer-group's consumers more performant by adding indexes in the in-memory db, instead of relying on "manual" looping which is very expensive when several thousands of consumers exist.

Testing is provided by existing tests.

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
