### PR TITLE
fix: do not require name/id for filter-chain entities

### DIFF
--- a/pkg/file/codegen/main.go
+++ b/pkg/file/codegen/main.go
@@ -76,14 +76,7 @@ func main() {
 		},
 	}
 
-	schema.Definitions["FFilterChain"].AnyOf = []*jsonschema.Type{
-		{
-			Required: []string{"filters", "name"},
-		},
-		{
-			Required: []string{"filters", "id"},
-		},
-	}
+	schema.Definitions["FFilterChain"].Required = []string{"filters"}
 
 	schema.Definitions["FFilterChain"].Properties["enabled"] = &jsonschema.Type{
 		Type: "boolean",

--- a/pkg/file/kong_json_schema.json
+++ b/pkg/file/kong_json_schema.json
@@ -618,6 +618,9 @@
       "type": "object"
     },
     "FFilterChain": {
+      "required": [
+        "filters"
+      ],
       "properties": {
         "created_at": {
           "type": "integer"
@@ -654,21 +657,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "anyOf": [
-        {
-          "required": [
-            "filters",
-            "name"
-          ]
-        },
-        {
-          "required": [
-            "filters",
-            "id"
-          ]
-        }
-      ]
+      "type": "object"
     },
     "FLicense": {
       "properties": {

--- a/pkg/file/readfile_test.go
+++ b/pkg/file/readfile_test.go
@@ -364,6 +364,57 @@ kong.log.set_serialize_value("span_id", parse_traceid(ngx.ctx.KONG_SPANS[1].span
 							},
 						},
 					},
+					{
+						Service: kong.Service{
+							Name: kong.String("service-with-filter-chain"),
+							Host: kong.String("test"),
+						},
+						Routes: []*FRoute{
+							{
+								Route: kong.Route{
+									Name:      kong.String("route-with-filter-chain"),
+									Hosts:     kong.StringSlice("test"),
+									Protocols: kong.StringSlice("http"),
+								},
+								FilterChains: []*FFilterChain{
+									{
+										FilterChain: kong.FilterChain{
+											Filters: []*kong.Filter{
+												{
+													Name:   kong.String("filter-1"),
+													Config: kong.JSONRawMessage(`{"add":{"headers":["x-foo:123456"]}}`),
+												},
+												{
+													Name:   kong.String("filter-2"),
+													Config: kong.JSONRawMessage(`"my config"`),
+												},
+												{
+													Name: kong.String("filter-3"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						FilterChains: []*FFilterChain{
+							{
+								FilterChain: kong.FilterChain{
+									Filters: []*kong.Filter{
+										{
+											Name:   kong.String("filter-1"),
+											Config: kong.JSONRawMessage(`{"add":{"headers":["x-foo:123456"]}}`),
+										},
+										{
+											Name:    kong.String("filter-2"),
+											Config:  kong.JSONRawMessage(`"{\n  \"test\": 123\n}\n"`),
+											Enabled: kong.Bool(true),
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				Consumers: []FConsumer{
 					{

--- a/pkg/file/testdata/valid/filter-chains.yaml
+++ b/pkg/file/testdata/valid/filter-chains.yaml
@@ -1,0 +1,32 @@
+services:
+- name: service-with-filter-chain
+  host: test
+  routes:
+  - hosts:
+    - test
+    name: route-with-filter-chain
+    protocols:
+    - http
+    filter_chains:
+    - filters:
+      - config:
+          add:
+            headers:
+            - x-foo:123456
+        name: filter-1
+      - config: my config
+        name: filter-2
+      - name: filter-3
+  filter_chains:
+  - filters:
+    - config:
+        add:
+          headers:
+          - x-foo:123456
+      name: filter-1
+    - config: |
+        {
+          "test": 123
+        }
+      enabled: true
+      name: filter-2


### PR DESCRIPTION
### Summary

This relaxes the JSON schema for filter chain entities to not require `name` or `id`. Filter chains are _always_ associated with a service or a route and therefore do not require a name/id for indexing.

### Issues resolved

KAG-4005

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes