### PR TITLE
feat: make the DECK_ envvar prefix configurable

### DIFF
--- a/pkg/file/template.go
+++ b/pkg/file/template.go
@@ -9,11 +9,19 @@ import (
 	"text/template"
 )
 
+// default env var prefix, can be set using SetEnvVarPrefix
+var envVarPrefix = "DECK_"
+
+// SetEnvVarPrefix sets the prefix for environment variables used in the state file.
+// The default prefix is "DECK_". This sets a library global(!!) value.
+func SetEnvVarPrefix(prefix string) {
+	envVarPrefix = prefix
+}
+
 func getPrefixedEnvVar(key string) (string, error) {
-	const envVarPrefix = "DECK_"
 	if !strings.HasPrefix(key, envVarPrefix) {
 		return "", fmt.Errorf("environment variables in the state file must "+
-			"be prefixed with 'DECK_', found: '%s'", key)
+			"be prefixed with '%s', found: '%s'", envVarPrefix, key)
 	}
 	value, exists := os.LookupEnv(key)
 	if !exists {
@@ -25,10 +33,9 @@ func getPrefixedEnvVar(key string) (string, error) {
 // getPrefixedEnvVarMocked is used when we mock the env variables while rendering a template.
 // It will always return the name of the environment variable in this case.
 func getPrefixedEnvVarMocked(key string) (string, error) {
-	const envVarPrefix = "DECK_"
 	if !strings.HasPrefix(key, envVarPrefix) {
 		return "", fmt.Errorf("environment variables in the state file must "+
-			"be prefixed with 'DECK_', found: '%s'", key)
+			"be prefixed with '%s', found: '%s'", envVarPrefix, key)
 	}
 	return key, nil
 }

--- a/pkg/file/template_test.go
+++ b/pkg/file/template_test.go
@@ -1,0 +1,74 @@
+package file
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_SetEnvVarPrefix(t *testing.T) {
+	oldPrefix := envVarPrefix
+	prefix := "NEW_PREFIX_"
+	SetEnvVarPrefix(prefix)
+	if envVarPrefix != prefix {
+		envVarPrefix = oldPrefix
+		t.Errorf("Expected prefix %q, but got %q", prefix, envVarPrefix)
+	}
+	envVarPrefix = oldPrefix
+}
+
+func Test_getPrefixedEnvVar(t *testing.T) {
+	key := "DECK_MY_VARIABLE"
+	expectedValue := "my_value"
+	os.Setenv(key, expectedValue)
+
+	value, err := getPrefixedEnvVar(key)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if value != expectedValue {
+		t.Errorf("Expected value %q, but got %q", expectedValue, value)
+	}
+
+	// Clean up
+	os.Unsetenv(key)
+}
+
+func Test_renderTemplate(t *testing.T) {
+	content := "Hello, ${{ env \"DECK_MY_VARIABLE\" }}!"
+	expectedOutput := "Hello, my_value!"
+	mockEnvVars := false
+
+	os.Setenv("DECK_MY_VARIABLE", "my_value")
+
+	output, err := renderTemplate(content, mockEnvVars)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if output != expectedOutput {
+		t.Errorf("Expected output %q, but got %q", expectedOutput, output)
+	}
+	os.Unsetenv("DECK_MY_VARIABLE")
+}
+
+func Test_renderTemplateCustomPrefix(t *testing.T) {
+	oldPrefix := envVarPrefix
+	SetEnvVarPrefix("PREFIX_")
+	content := "Hello, ${{ env \"PREFIX_MY_VARIABLE\" }}!"
+	expectedOutput := "Hello, my_value!"
+	mockEnvVars := false
+
+	os.Setenv("PREFIX_MY_VARIABLE", "my_value")
+
+	output, err := renderTemplate(content, mockEnvVars)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if output != expectedOutput {
+		t.Errorf("Expected output %q, but got %q", expectedOutput, output)
+	}
+	os.Unsetenv("PREFIX_MY_VARIABLE")
+	SetEnvVarPrefix(oldPrefix)
+}


### PR DESCRIPTION

### Summary

default remains DECK_ so no functional changes to existing code. also adds tests for rendering files.

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
