### PR TITLE
fix: correctly compare compressed/expanded ipv6 in targets

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1041,7 +1041,10 @@ var (
 	IPv6HasBracketPattern = regexp.MustCompile(`\[\S+\]$`)
 )
 
-func isIPv6(hostname string) bool {
+// hasIPv6Format checks if the hostname is in ipv6 format.
+// This is a best effort check, it doesn't guarantee that the hostname is a valid ipv6 address,
+// but it checks if the hostname has more than 2 colons.
+func hasIPv6Format(hostname string) bool {
 	parts := strings.Split(hostname, ":")
 	return len(parts) > 2
 }
@@ -1140,7 +1143,7 @@ func (b *stateBuilder) ingestTargets(targets []kong.Target) error {
 	for _, t := range targets {
 		t := t
 
-		if t.Target != nil && isIPv6(*t.Target) {
+		if t.Target != nil && hasIPv6Format(*t.Target) {
 			normalizedTarget, err := normalizeIPv6(*t.Target)
 			if err != nil {
 				return err

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -764,6 +764,36 @@ func Test_stateBuilder_ingestTargets(t *testing.T) {
 			},
 		},
 		{
+			name: "expands IPv6 address with square brackets correctly",
+			fields: fields{
+				currentState: emptyState(),
+			},
+			args: args{
+				targets: []kong.Target{
+					{
+						ID:     kong.String("d6e7f8a9-bcde-1234-5678-9abcdef01234"),
+						Target: kong.String("[::1]"),
+						Upstream: &kong.Upstream{
+							ID: kong.String("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantState: &utils.KongRawState{
+				Targets: []*kong.Target{
+					{
+						ID:     kong.String("d6e7f8a9-bcde-1234-5678-9abcdef01234"),
+						Target: kong.String("[0000:0000:0000:0000:0000:0000:0000:0001]:8000"),
+						Weight: kong.Int(100),
+						Upstream: &kong.Upstream{
+							ID: kong.String("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "handles invalid IPv6 address correctly",
 			fields: fields{
 				currentState: emptyState(),
@@ -772,6 +802,42 @@ func Test_stateBuilder_ingestTargets(t *testing.T) {
 				targets: []kong.Target{
 					{
 						Target: kong.String("[invalid:ipv6::address]:1326"),
+						Upstream: &kong.Upstream{
+							ID: kong.String("b1c2d3e4-f5a6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			wantState: &utils.KongRawState{},
+		},
+		{
+			name: "handles invalid IPv6 address correctly",
+			fields: fields{
+				currentState: emptyState(),
+			},
+			args: args{
+				targets: []kong.Target{
+					{
+						Target: kong.String("1:2:3:4"),
+						Upstream: &kong.Upstream{
+							ID: kong.String("b1c2d3e4-f5a6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			wantState: &utils.KongRawState{},
+		},
+		{
+			name: "handles invalid IPv6 address correctly",
+			fields: fields{
+				currentState: emptyState(),
+			},
+			args: args{
+				targets: []kong.Target{
+					{
+						Target: kong.String("this:is:nuts:!"),
 						Upstream: &kong.Upstream{
 							ID: kong.String("b1c2d3e4-f5a6-7890-abcd-ef1234567890"),
 						},

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -704,7 +704,7 @@ func Test_stateBuilder_ingestTargets(t *testing.T) {
 			},
 		},
 		{
-			name: "expands IPv6 address correctly",
+			name: "expands IPv6 address and port correctly",
 			fields: fields{
 				currentState: emptyState(),
 			},
@@ -725,6 +725,36 @@ func Test_stateBuilder_ingestTargets(t *testing.T) {
 					{
 						ID:     kong.String("d6e7f8a9-bcde-1234-5678-9abcdef01234"),
 						Target: kong.String("[2001:0db8:fd73:0000:0000:0000:0000:000e]:1326"),
+						Weight: kong.Int(100),
+						Upstream: &kong.Upstream{
+							ID: kong.String("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "expands IPv6 address correctly",
+			fields: fields{
+				currentState: emptyState(),
+			},
+			args: args{
+				targets: []kong.Target{
+					{
+						ID:     kong.String("d6e7f8a9-bcde-1234-5678-9abcdef01234"),
+						Target: kong.String("::1"),
+						Upstream: &kong.Upstream{
+							ID: kong.String("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantState: &utils.KongRawState{
+				Targets: []*kong.Target{
+					{
+						ID:     kong.String("d6e7f8a9-bcde-1234-5678-9abcdef01234"),
+						Target: kong.String("[0000:0000:0000:0000:0000:0000:0000:0001]:8000"),
 						Weight: kong.Int(100),
 						Upstream: &kong.Upstream{
 							ID: kong.String("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -703,6 +703,54 @@ func Test_stateBuilder_ingestTargets(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "expands IPv6 address correctly",
+			fields: fields{
+				currentState: emptyState(),
+			},
+			args: args{
+				targets: []kong.Target{
+					{
+						ID:     kong.String("d6e7f8a9-bcde-1234-5678-9abcdef01234"),
+						Target: kong.String("[2001:db8:fd73::e]:1326"),
+						Upstream: &kong.Upstream{
+							ID: kong.String("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantState: &utils.KongRawState{
+				Targets: []*kong.Target{
+					{
+						ID:     kong.String("d6e7f8a9-bcde-1234-5678-9abcdef01234"),
+						Target: kong.String("[2001:0db8:fd73:0000:0000:0000:0000:000e]:1326"),
+						Weight: kong.Int(100),
+						Upstream: &kong.Upstream{
+							ID: kong.String("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles invalid IPv6 address correctly",
+			fields: fields{
+				currentState: emptyState(),
+			},
+			args: args{
+				targets: []kong.Target{
+					{
+						Target: kong.String("[invalid:ipv6::address]:1326"),
+						Upstream: &kong.Upstream{
+							ID: kong.String("b1c2d3e4-f5a6-7890-abcd-ef1234567890"),
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			wantState: &utils.KongRawState{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When syncing a target with a compressed IPv6 (for example `[2001:db8:fd73::e]:1326`) decK can successfully create it but it fails to detect its existence when pulling the config from the API because the CP expands the address (for example to `[2001:0db8:fd73:0000:0000:0000:0000:000e]:1326`) causing decK to attempt to recreate the target and failing because the target already exists.

This commit fixes this by using some helpers to expand the ipv6 before trying to sync/dump.

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
