### PR TITLE
add custom entities to dump.Get

### DIFF
--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -41,7 +41,7 @@ type KongRawState struct {
 
 	Consumers      []*kong.Consumer
 	ConsumerGroups []*kong.ConsumerGroupObject
-	CustomEntities []*custom.Entity
+	CustomEntities []custom.Entity
 
 	Vaults   []*kong.Vault
 	Licenses []*kong.License


### PR DESCRIPTION
### Summary

Add custom entities in `dump.Get` to support dumping custom entities

### Full changelog

* [Feature] Support dumping custom entities

### Issues resolved

Fix #110 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing on Universal
- [x] Manual testing on Kubernetes
