### PR TITLE
fix: Fix yaml files rendered for expression routes

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1376,12 +1376,12 @@ func (b *stateBuilder) ingestRoute(r FRoute) error {
 	// On the other hand, Konnect can support only one schema including all
 	// fields from 'traditional' and 'expressions' router schemas.
 	// This may be problematic when it comes to defaults injection, because
-	// the defaults for the 'traditiona' router schema can be wrongly injected
+	// the defaults for the 'traditional' router schema can be wrongly injected
 	// into the 'expressions' route configuration.
 	//
 	// Here we make sure that only the fields that are supported for a given
 	// router version are set in the route configuration.
-	if b.isKonnect && hasExpression && !(hasRegexPriority || hasPathHandling) {
+	if hasExpression && !(hasRegexPriority || hasPathHandling) {
 		if r.Route.PathHandling != nil {
 			r.Route.PathHandling = nil
 		}


### PR DESCRIPTION
### Summary

At the moment, when we run deck file render, all routes get `regex_priority` field. This field is not applicable in the case of expression routes. A rendered file from deck containing expression routes, thus failed to sync directly.

This change ensures that expression routes do not get the fields of traditional routes.

Test for change added in separate branch. 

### Issues resolved

Fix [#1250](https://github.com/Kong/deck/issues/1250)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

Manually tested locally on Kong Gateway running via Docker. Tested this with both traditional router and expression router.
