### PR TITLE
test: Valid expression routes building

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1376,12 +1376,12 @@ func (b *stateBuilder) ingestRoute(r FRoute) error {
 	// On the other hand, Konnect can support only one schema including all
 	// fields from 'traditional' and 'expressions' router schemas.
 	// This may be problematic when it comes to defaults injection, because
-	// the defaults for the 'traditiona' router schema can be wrongly injected
+	// the defaults for the 'traditional' router schema can be wrongly injected
 	// into the 'expressions' route configuration.
 	//
 	// Here we make sure that only the fields that are supported for a given
 	// router version are set in the route configuration.
-	if b.isKonnect && hasExpression && !(hasRegexPriority || hasPathHandling) {
+	if hasExpression && !(hasRegexPriority || hasPathHandling) {
 		if r.Route.PathHandling != nil {
 			r.Route.PathHandling = nil
 		}

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -3064,7 +3064,6 @@ func Test_stateBuilder_ingestRouteKonnectTraditionalRoute(t *testing.T) {
 			wantState: &utils.KongRawState{
 				Routes: []*kong.Route{
 					{
-						ID:            kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Name:          kong.String("foo"),
 						PreserveHost:  kong.Bool(false),
 						RegexPriority: kong.Int(0),
@@ -3075,23 +3074,30 @@ func Test_stateBuilder_ingestRouteKonnectTraditionalRoute(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			b := &stateBuilder{
-				currentState: tt.fields.currentState,
-				isKonnect:    true,
-			}
-			b.rawState = &utils.KongRawState{}
-			d, _ := utils.GetDefaulter(ctx, defaulterTestOpts)
-			b.defaulter = d
-			b.intermediate, _ = state.NewKongState()
-			if err := b.ingestRoute(tt.args.route); (err != nil) != tt.wantErr {
-				t.Errorf("stateBuilder.ingestRoute() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			assert.Equal(tt.wantState, b.rawState)
-			assert.NotNil(b.rawState.Routes[0].RegexPriority, "RegexPriority should not be nil")
-		})
+		for _, isKonnect := range []bool{true, false} {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := context.Background()
+				b := &stateBuilder{
+					currentState: tt.fields.currentState,
+					isKonnect:    isKonnect,
+				}
+				b.rawState = &utils.KongRawState{}
+				d, _ := utils.GetDefaulter(ctx, defaulterTestOpts)
+				b.defaulter = d
+				b.intermediate, _ = state.NewKongState()
+				if err := b.ingestRoute(tt.args.route); (err != nil) != tt.wantErr {
+					t.Errorf("stateBuilder.ingestRoute() error = %v, wantErr %v", err, tt.wantErr)
+				}
+
+				// Not checking ID equality, as it is unnecessary for testing functionality
+				b.rawState.Routes[0].ID = nil
+
+				assert.Equal(b.rawState, tt.wantState)
+				assert.NotNil(b.rawState.Routes[0].RegexPriority, "RegexPriority should not be nil")
+			})
+		}
 	}
 }
 
@@ -3128,7 +3134,6 @@ func Test_stateBuilder_ingestRouteKonnectExpressionRoute(t *testing.T) {
 			wantState: &utils.KongRawState{
 				Routes: []*kong.Route{
 					{
-						ID:           kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Name:         kong.String("foo"),
 						PreserveHost: kong.Bool(false),
 						Expression:   kong.String(`'(http.path == "/test") || (http.path ^= "/test/")'`),
@@ -3141,21 +3146,27 @@ func Test_stateBuilder_ingestRouteKonnectExpressionRoute(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			b := &stateBuilder{
-				currentState: tt.fields.currentState,
-				isKonnect:    true,
-			}
-			b.rawState = &utils.KongRawState{}
-			d, _ := utils.GetDefaulter(ctx, defaulterTestOpts)
-			b.defaulter = d
-			b.intermediate, _ = state.NewKongState()
-			if err := b.ingestRoute(tt.args.route); (err != nil) != tt.wantErr {
-				t.Errorf("stateBuilder.ingestRoute() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			assert.Equal(tt.wantState, b.rawState)
-			assert.Nil(b.rawState.Routes[0].RegexPriority, "RegexPriority should be nil")
-		})
+		for _, isKonnect := range []bool{true, false} {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := context.Background()
+				b := &stateBuilder{
+					currentState: tt.fields.currentState,
+					isKonnect:    isKonnect,
+				}
+				b.rawState = &utils.KongRawState{}
+				d, _ := utils.GetDefaulter(ctx, defaulterTestOpts)
+				b.defaulter = d
+				b.intermediate, _ = state.NewKongState()
+				if err := b.ingestRoute(tt.args.route); (err != nil) != tt.wantErr {
+					t.Errorf("stateBuilder.ingestRoute() error = %v, wantErr %v", err, tt.wantErr)
+				}
+
+				// Not checking ID equality, as it is unnecessary for testing functionality
+				b.rawState.Routes[0].ID = nil
+
+				assert.Equal(tt.wantState, b.rawState)
+				assert.Nil(b.rawState.Routes[0].RegexPriority, "RegexPriority should be nil")
+			})
+		}
 	}
 }

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -3032,7 +3032,7 @@ func Test_getStripPathBasedOnProtocols(t *testing.T) {
 	}
 }
 
-func Test_stateBuilder_ingestRouteKonnect(t *testing.T) {
+func Test_stateBuilder_ingestRouteKonnectTraditionalRoute(t *testing.T) {
 	assert := assert.New(t)
 	rand.Seed(42)
 	type fields struct {
@@ -3074,6 +3074,43 @@ func Test_stateBuilder_ingestRouteKonnect(t *testing.T) {
 				},
 			},
 		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			b := &stateBuilder{
+				currentState: tt.fields.currentState,
+				isKonnect:    true,
+			}
+			b.rawState = &utils.KongRawState{}
+			d, _ := utils.GetDefaulter(ctx, defaulterTestOpts)
+			b.defaulter = d
+			b.intermediate, _ = state.NewKongState()
+			if err := b.ingestRoute(tt.args.route); (err != nil) != tt.wantErr {
+				t.Errorf("stateBuilder.ingestRoute() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(tt.wantState, b.rawState)
+			assert.NotNil(b.rawState.Routes[0].RegexPriority, "RegexPriority should not be nil")
+		})
+	}
+}
+
+func Test_stateBuilder_ingestRouteKonnectExpressionRoute(t *testing.T) {
+	assert := assert.New(t)
+	rand.Seed(42)
+	type fields struct {
+		currentState *state.KongState
+	}
+	type args struct {
+		route FRoute
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		wantState *utils.KongRawState
+	}{
 		{
 			name: "expression route",
 			fields: fields{
@@ -3091,7 +3128,7 @@ func Test_stateBuilder_ingestRouteKonnect(t *testing.T) {
 			wantState: &utils.KongRawState{
 				Routes: []*kong.Route{
 					{
-						ID:           kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						ID:           kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Name:         kong.String("foo"),
 						PreserveHost: kong.Bool(false),
 						Expression:   kong.String(`'(http.path == "/test") || (http.path ^= "/test/")'`),
@@ -3118,6 +3155,7 @@ func Test_stateBuilder_ingestRouteKonnect(t *testing.T) {
 				t.Errorf("stateBuilder.ingestRoute() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(tt.wantState, b.rawState)
+			assert.Nil(b.rawState.Routes[0].RegexPriority, "RegexPriority should be nil")
 		})
 	}
 }


### PR DESCRIPTION
Test for PR: https://github.com/Kong/go-database-reconciler/pull/116

One test for ingest routes are separated into two to deal with different kinds of routes - expression and traditional.
Added assertion to ensure that `regex_priority` is not present in expression route but present in the traditional routes.