### PR TITLE
Fix: Expression route handling fix for Konnect and < v3.7.0

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ var (
 	Kong140Version = semver.MustParse("1.4.0")
 	Kong300Version = semver.MustParse("3.0.0")
 	Kong340Version = semver.MustParse("3.4.0")
+	Kong370Version = semver.MustParse("3.7.0")
 )
 
 var ErrorConsumerGroupUpgrade = errors.New(


### PR DESCRIPTION
### Summary

v3.7.0 added changes to allow traditional route fields with expression routes, thus making expression router a superset of traditional router.
Ref: https://github.com/Kong/kong/pull/12667
Thus, keys like regex_priority are not supported in versions lesser than 3.7.0.

Added a gating logic in state builder for the necessary changes and fixed tests.
Fix #1250

### Full changelog

* Added gating logic in state builder
* Fixed tests for the same

### Issues resolved

Fix [#1250](https://github.com/Kong/deck/issues/1250)

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
- [x] Manual testing using deck with gateway versions 3.6.1.7 and 3.7.1.2
