### PR TITLE
fix: send change events always

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -681,18 +681,18 @@ func (sc *Syncer) Solve(ctx context.Context, parallelism int, dry bool, isJSONOu
 			// sync mode
 			// fire the request to Kong
 			result, err = sc.processor.Do(ctx, e.Kind, e.Op, e)
-			if err != nil {
-				// TODO https://github.com/Kong/go-database-reconciler/issues/22 this does not print, but is switched on
-				// sc.enableEntityActions because the existing behavior returns a result from the anon Run function.
-				// Refactoring should use only the channel and simplify the return, probably to just an error (all the other
-				// data will have been sent through the result channel).
-				if sc.enableEntityActions {
-					actionResult.Error = err
-					select {
-					case sc.resultChan <- actionResult:
-					case <-ctx.Done():
-					}
+			// TODO https://github.com/Kong/go-database-reconciler/issues/22 this does not print, but is switched on
+			// sc.enableEntityActions because the existing behavior returns a result from the anon Run function.
+			// Refactoring should use only the channel and simplify the return, probably to just an error (all the other
+			// data will have been sent through the result channel).
+			if sc.enableEntityActions {
+				actionResult.Error = err
+				select {
+				case sc.resultChan <- actionResult:
+				case <-ctx.Done():
 				}
+			}
+			if err != nil {
 				return nil, &crud.ActionError{
 					OperationType: e.Op,
 					Kind:          e.Kind,


### PR DESCRIPTION
### Summary

Fixes a bug in the event sender. The original structure of this section meant that GDR only sent change events to the channel if they had encountered in an error. This did not make [the KIC DB mode error event generator](https://github.com/Kong/kubernetes-ingress-controller/pull/5785) unhappy, but did not work very well for https://github.com/Kong/kubernetes-ingress-controller/pull/6131, as it did not see most change events. Whoops.

This assigns the error to the event regardless of whether it's nil or not (it'll either populate or just remain nil) and sends the event off before checking for a non-nil error and performing the error return.

After this change, the channel will receive successful events also. This was the original intent, but the breakage went unnoticed til I tried to actual look at successful events.