### PR TITLE
fix: do not fetch oauth2 from konnect

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -166,14 +166,17 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 		return nil
 	})
 
-	group.Go(func() error {
-		oauth2Creds, err := GetAllOauth2Creds(ctx, client, config.SelectorTags)
-		if err != nil {
-			return fmt.Errorf("oauth2: %w", err)
-		}
-		state.Oauth2Creds = oauth2Creds
-		return nil
-	})
+	// OAuth2 credentials are not supported in Konnect.
+	if config.KonnectControlPlane == "" {
+		group.Go(func() error {
+			oauth2Creds, err := GetAllOauth2Creds(ctx, client, config.SelectorTags)
+			if err != nil {
+				return fmt.Errorf("oauth2: %w", err)
+			}
+			state.Oauth2Creds = oauth2Creds
+			return nil
+		})
+	}
 
 	group.Go(func() error {
 		aclGroups, err := GetAllACLGroups(ctx, client, config.SelectorTags)


### PR DESCRIPTION
### Summary

As Konnect does not support OAuth2 credentials, we should not try to fetch them when dumping config (currently it returns 404s).

### Issues resolved

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6240.
