### PR TITLE
chore(ci): remove EOLd versions from test matrix

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -15,19 +15,7 @@ jobs:
     strategy:
       matrix:
         kong_image:
-        - 'kong/kong-gateway:1.5.0.11'
-        - 'kong/kong-gateway:2.1.4.6'
-        - 'kong/kong-gateway:2.2.1.3'
-        - 'kong/kong-gateway:2.3.3.4'
-        - 'kong/kong-gateway:2.4.1.3'
-        - 'kong/kong-gateway:2.5.1.2'
-        - 'kong/kong-gateway:2.6.0.2'
-        - 'kong/kong-gateway:2.7'
         - 'kong/kong-gateway:2.8'
-        - 'kong/kong-gateway:3.0'
-        - 'kong/kong-gateway:3.1'
-        - 'kong/kong-gateway:3.2'
-        - 'kong/kong-gateway:3.3'
         - 'kong/kong-gateway:3.4'
         - 'kong/kong-gateway:3.5'
         - 'kong/kong-gateway:3.6'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -15,21 +15,7 @@ jobs:
     strategy:
       matrix:
         kong_image:
-        - 'kong:1.4.3'
-        - 'kong:1.5.1'
-        - 'kong:2.0.5'
-        - 'kong:2.1.4'
-        - 'kong:2.2.2'
-        - 'kong:2.3.3'
-        - 'kong:2.4.1'
-        - 'kong:2.5.1'
-        - 'kong:2.6.0'
-        - 'kong:2.7'
         - 'kong:2.8'
-        - 'kong:3.0'
-        - 'kong:3.1'
-        - 'kong:3.2'
-        - 'kong:3.3'
         - 'kong:3.4'
         - 'kong:3.5'
         - 'kong:3.6'


### PR DESCRIPTION
### Summary

According to https://docs.konghq.com/gateway/latest/support-policy/#older-versions there's a handful of versions that already reached EOL.

This PR removes them from the test matrix.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
