### PR TITLE
 fix(diff): support auto fields

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -621,8 +621,8 @@ func (sc *Syncer) Solve(ctx context.Context, parallelism int, dry bool, isJSONOu
 				}
 
 				var oldPlugin *kong.Plugin
-				if e.OldObj != nil && e.OldObj.(*state.Plugin) != nil {
-					oldPlugin = &e.OldObj.(*state.Plugin).Plugin
+				if kongStatePlugin, ok := e.OldObj.(*state.Plugin); ok {
+					oldPlugin = &kongStatePlugin.Plugin
 				}
 				newPlugin := &pluginCopy.Plugin
 				if err := kong.FillPluginsDefaultsAutoFields(newPlugin, schema, oldPlugin); err != nil {

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -609,10 +609,7 @@ func (sc *Syncer) Solve(ctx context.Context, parallelism int, dry bool, isJSONOu
 		// that will be used for the diff. This is needed to avoid highlighting
 		// default values that were populated by Kong as differences.
 		if plugin, ok := e.Obj.(*state.Plugin); ok {
-			pluginCopy := &state.Plugin{
-				Plugin: *plugin.DeepCopy(),
-				Meta:   plugin.Meta,
-			}
+			pluginCopy := &state.Plugin{Plugin: *plugin.DeepCopy()}
 			e.Obj = pluginCopy
 
 			exists, err := utils.WorkspaceExists(ctx, sc.kongClient)
@@ -623,8 +620,13 @@ func (sc *Syncer) Solve(ctx context.Context, parallelism int, dry bool, isJSONOu
 					return nil, err
 				}
 
-				if err := kong.FillPluginsDefaults(&pluginCopy.Plugin, schema); err != nil {
-					return nil, fmt.Errorf("failed filling plugin defaults: %w", err)
+				var oldPlugin *kong.Plugin
+				if e.OldObj != nil && e.OldObj.(*state.Plugin) != nil {
+					oldPlugin = &e.OldObj.(*state.Plugin).Plugin
+				}
+				newPlugin := &pluginCopy.Plugin
+				if err := kong.FillPluginsDefaultsAutoFields(newPlugin, schema, oldPlugin); err != nil {
+					return nil, fmt.Errorf("failed processing auto fields: %w", err)
 				}
 			}
 		}

--- a/pkg/types/core.go
+++ b/pkg/types/core.go
@@ -232,6 +232,7 @@ func NewEntity(t EntityType, opts EntityOpts) (Entity, error) {
 				kind:         entityTypeToKind(Plugin),
 				currentState: opts.CurrentState,
 				targetState:  opts.TargetState,
+				kongClient:   opts.KongClient,
 			},
 		}, nil
 	case Consumer:

--- a/tests/integration/testdata/sync/034-fill-auto-oauth2/kong.yaml
+++ b/tests/integration/testdata/sync/034-fill-auto-oauth2/kong.yaml
@@ -1,0 +1,5 @@
+_format_version: "3.0"
+plugins:
+  - name: oauth2
+    config:
+      enable_password_grant: true


### PR DESCRIPTION
### Summary

fix(diff): support auto fields
    
    call the new utils function FillPluginsDefaultsAutoFields from  go-kong
    to ensure auto fields are considered when doing the diff

fix(crud): detect operation correctly

    fixes a bug that was introduced in
    e72f4c2de6609998d5e5671e14a9f7c0cd6a4c3e where noops were still detected
    as updates. That happened because of a check happening in plugin.go that
    detected the crud operation based on a diff.
    When done without considering default/auto fields, this check would see
    differences where there were none. This resulted in unnecessary updates
    to the DB and wrong diff strings during `sync` and `diff`.
    
    This commit adds defaults/auto fields to the configuration used for that
    diff.

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

[KAG-5210](https://konghq.atlassian.net/browse/KAG-5210)

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes


[KAG-5210]: https://konghq.atlassian.net/browse/KAG-5210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ