### PR TITLE
ci: fix codegen

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -54,6 +54,16 @@ jobs:
             echo "result=true" >> $GITHUB_OUTPUT
           fi
 
+  codegen:
+    runs-on: ubuntu-latest
+    needs:
+    - up-to-date
+    if: needs.up-to-date.outputs.status != 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - run: make update-codegen verify-codegen
+
   enterprise-integration-tests:
     needs:
     - should-run-with-secrets
@@ -76,6 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - up-to-date
+      - codegen
       - integration-tests
       - enterprise-integration-tests
     if: always()

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+function install-deepcopy-gen() {
+	go install k8s.io/code-generator/cmd/deepcopy-gen
+}
+
+function run-deepcopy-gen() {
+  local output_file="${1}"
+  deepcopy-gen \
+    --output-file zz_generated.deepcopy.go \
+    --go-header-file scripts/header-template.go.tmpl \
+    "${output_file}"
+}

--- a/scripts/update-deepcopy-gen.sh
+++ b/scripts/update-deepcopy-gen.sh
@@ -1,23 +1,11 @@
 #!/bin/bash -e
 
-go install k8s.io/code-generator/cmd/deepcopy-gen
-TMP_DIR=$(mktemp -d)
-trap "rm -rf $TMP_DIR" EXIT
+set -x
 
-# konnect package
-deepcopy-gen --input-dirs github.com/kong/go-database-reconciler/pkg/konnect \
-  -O zz_generated.deepcopy \
-  --go-header-file scripts/header-template.go.tmpl \
-  --output-base $TMP_DIR
+SCRIPT_DIR="$(dirname $0)"
+source ${SCRIPT_DIR}/_lib.sh
 
-cp $TMP_DIR/github.com/kong/go-database-reconciler/pkg/konnect/zz_generated.deepcopy.go \
-  pkg/konnect/zz_generated.deepcopy.go
+install-deepcopy-gen
 
-# file package
-deepcopy-gen --input-dirs github.com/kong/go-database-reconciler/pkg/file \
-  -O zz_generated.deepcopy \
-  --go-header-file scripts/header-template.go.tmpl \
-  --output-base $TMP_DIR
-
-cp $TMP_DIR/github.com/kong/go-database-reconciler/pkg/file/zz_generated.deepcopy.go \
-  pkg/file/zz_generated.deepcopy.go
+run-deepcopy-gen ./pkg/konnect
+run-deepcopy-gen ./pkg/file

--- a/scripts/verify-codegen.sh
+++ b/scripts/verify-codegen.sh
@@ -1,7 +1,12 @@
 #!/bin/bash -e
 
-FILE="kong_json_schema.json"
-cp file/${FILE} /tmp/${FILE}
+set -x
+
+SCHEMA_FILE_NAME="kong_json_schema.json"
+SOURCE_FILE_PATH="pkg/file/${SCHEMA_FILE_NAME}"
+TMP_SCHEMA_FILE_PATH="/tmp/${SCHEMA_FILE_NAME}"
+
+cp "${SOURCE_FILE_PATH}" "${TMP_SCHEMA_FILE_PATH}"
 go generate ./...
 
-diff -u /tmp/${FILE} file/${FILE}
+diff -u "${TMP_SCHEMA_FILE_PATH}" "${SOURCE_FILE_PATH}"


### PR DESCRIPTION
### Summary

Fix code generation and add it to CI.

Without this change we get:

```
make update-codegen ; make verify-codegen
./scripts/update-deepcopy-gen.sh
unknown flag: --input-dirs
Usage of deepcopy-gen:
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
      --bounding-dirs strings            Comma-separated list of import paths which bound the types for which deep-copies will be generated.
      --go-header-file string            the path to a file containing boilerplate header text; the string "YEAR" will be replaced with the current 4-digit year
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
      --output-file string               the name of the file to be generated (default "generated.deepcopy.go")
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
unknown flag: --input-dirs
make: *** [Makefile:19: update-codegen] Error 2
./scripts/verify-codegen.sh
cp: file/kong_json_schema.json: No such file or directory
make: *** [Makefile:14: verify-codegen] Error 1
```

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
