### PR TITLE
fix: returning a validation error in case of wrong configuration.

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -19,6 +19,13 @@ import (
 
 const ratelimitingAdvancedPluginName = "rate-limiting-advanced"
 
+const (
+	primaryRelationConsumer      = "consumer"
+	primaryRelationConsumerGroup = "consumer-group"
+	primaryRelationRoute         = "route"
+	primaryRelationService       = "service"
+)
+
 type stateBuilder struct {
 	targetContent   *Content
 	rawState        *utils.KongRawState
@@ -488,7 +495,7 @@ func (b *stateBuilder) consumers() {
 		// plugins for the Consumer
 		var plugins []FPlugin
 		for _, p := range c.Plugins {
-			if err := checkForNestedForeignKeys(p.Plugin, "consumer"); err != nil {
+			if err := checkForNestedForeignKeys(p.Plugin, primaryRelationConsumer); err != nil {
 				b.err = err
 				return
 			}
@@ -924,7 +931,7 @@ func (b *stateBuilder) ingestService(s *FService) error {
 	// plugins for the service
 	var plugins []FPlugin
 	for _, p := range s.Plugins {
-		if err := checkForNestedForeignKeys(p.Plugin, "service"); err != nil {
+		if err := checkForNestedForeignKeys(p.Plugin, primaryRelationService); err != nil {
 			return err
 		}
 		p.Service = utils.GetServiceReference(s.Service)
@@ -1443,7 +1450,7 @@ func (b *stateBuilder) ingestRoute(r FRoute) error {
 	// plugins for the route
 	var plugins []FPlugin
 	for _, p := range r.Plugins {
-		if err := checkForNestedForeignKeys(p.Plugin, "route"); err != nil {
+		if err := checkForNestedForeignKeys(p.Plugin, primaryRelationRoute); err != nil {
 			return err
 		}
 		p.Route = utils.GetRouteReference(r.Route)
@@ -1584,19 +1591,19 @@ func defaulter(
 func checkForNestedForeignKeys(plugin kong.Plugin, primary string) error {
 	var errs []error
 
-	if primary != "consumer" && plugin.Consumer != nil && !utils.Empty(plugin.Consumer.ID) {
+	if primary != primaryRelationConsumer && plugin.Consumer != nil && !utils.Empty(plugin.Consumer.ID) {
 		errs = append(errs, fmt.Errorf("nesting consumer (%v) under %v-scoped plugin plugin (%v) is not allowed",
 			*plugin.Consumer.ID, primary, *plugin.Name))
 	}
-	if primary != "route" && plugin.Route != nil && !utils.Empty(plugin.Route.ID) {
+	if primary != primaryRelationRoute && plugin.Route != nil && !utils.Empty(plugin.Route.ID) {
 		errs = append(errs, fmt.Errorf("nesting route (%v) under %v-scoped plugin (%v) is not allowed",
 			*plugin.Route.ID, primary, *plugin.Name))
 	}
-	if primary != "service" && plugin.Service != nil && !utils.Empty(plugin.Service.ID) {
+	if primary != primaryRelationService && plugin.Service != nil && !utils.Empty(plugin.Service.ID) {
 		errs = append(errs, fmt.Errorf("nesting service (%v) under %v-scoped plugin (%v) is not allowed",
 			*plugin.Service.ID, primary, *plugin.Name))
 	}
-	if primary != "consumer-group" && plugin.ConsumerGroup != nil && !utils.Empty(plugin.ConsumerGroup.ID) {
+	if primary != primaryRelationConsumerGroup && plugin.ConsumerGroup != nil && !utils.Empty(plugin.ConsumerGroup.ID) {
 		errs = append(errs, fmt.Errorf("nesting consumer-group (%v) under %v-scoped plugin (%v) is not allowed",
 			*plugin.ConsumerGroup.ID, primary, *plugin.Name))
 	}

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1446,10 +1446,6 @@ func (b *stateBuilder) ingestRoute(r FRoute) error {
 		if err := checkForNestedForeignKeys(p.Plugin, "route"); err != nil {
 			return err
 		}
-		if p.Service != nil && !utils.Empty(p.Service.ID) {
-			return fmt.Errorf("nesting service (%v) under route-scoped plugin (%v) is not allowed", *p.Service.ID, *p.Name)
-		}
-
 		p.Route = utils.GetRouteReference(r.Route)
 		plugins = append(plugins, *p)
 	}

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1436,6 +1436,10 @@ func (b *stateBuilder) ingestRoute(r FRoute) error {
 	// plugins for the route
 	var plugins []FPlugin
 	for _, p := range r.Plugins {
+		if p.Service != nil && !utils.Empty(p.Service.ID) {
+			return fmt.Errorf("nesting service (%v) under route-scoped plugin (%v) is not allowed", *p.Service.ID, *p.Name)
+		}
+
 		p.Route = utils.GetRouteReference(r.Route)
 		plugins = append(plugins, *p)
 	}

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1600,5 +1600,9 @@ func checkForNestedForeignKeys(plugin kong.Plugin, primary string) error {
 		errs = append(errs, fmt.Errorf("nesting service (%v) under %v-scoped plugin (%v) is not allowed",
 			*plugin.Service.ID, primary, *plugin.Name))
 	}
+	if primary != "consumer-group" && plugin.ConsumerGroup != nil && !utils.Empty(plugin.ConsumerGroup.ID) {
+		errs = append(errs, fmt.Errorf("nesting consumer-group (%v) under %v-scoped plugin (%v) is not allowed",
+			*plugin.ConsumerGroup.ID, primary, *plugin.Name))
+	}
 	return errors.Join(errs...)
 }

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -6119,9 +6119,6 @@ func Test_Sync_Scoped_Plugins_3x(t *testing.T) {
 	runWhen(t, "enterprise", ">=3.0.0")
 	setup(t)
 
-	//client, err := getTestClient()
-	// require.NoError(t, err)
-
 	tests := []struct {
 		name          string
 		file          string

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -6114,3 +6114,40 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 		})
 	}
 }
+
+func Test_Sync_Scoped_Plugins_3x(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.0.0")
+	setup(t)
+
+	//client, err := getTestClient()
+	// require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		file          string
+		errorExpected string
+	}{
+		{
+			name:          "syncing route-scoped plugin with service field set",
+			file:          "testdata/sync/036-scoped-plugins-validation/route-plugins.yaml",
+			errorExpected: "building state: nesting service (example-service) under route-scoped plugin (request-transformer) is not allowed",
+		},
+		{
+			name:          "syncing service-scoped plugin with route and consumer field set",
+			file:          "testdata/sync/036-scoped-plugins-validation/service-plugins.yaml",
+			errorExpected: "building state: nesting consumer (foo) under service-scoped plugin plugin (request-transformer) is not allowed\nnesting route (example-route) under service-scoped plugin (request-transformer) is not allowed",
+		},
+		{
+			name:          "syncing consumer-scoped plugin with service and route field set",
+			file:          "testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml",
+			errorExpected: "building state: nesting route (example-route) under consumer-scoped plugin (request-transformer) is not allowed\nnesting service (example-service) under consumer-scoped plugin (request-transformer) is not allowed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := sync(tc.file)
+			require.Equal(t, tc.errorExpected, err.Error())
+		})
+	}
+}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -6115,8 +6115,8 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	}
 }
 
-func Test_Sync_Scoped_Plugins_3x(t *testing.T) {
-	runWhen(t, "enterprise", ">=3.0.0")
+func Test_Sync_Scoped_Plugins(t *testing.T) {
+	runWhen(t, "kong", "<3.0.0")
 	setup(t)
 
 	tests := []struct {
@@ -6137,6 +6137,40 @@ func Test_Sync_Scoped_Plugins_3x(t *testing.T) {
 		{
 			name:          "syncing consumer-scoped plugin with service and route field set",
 			file:          "testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml",
+			errorExpected: "building state: nesting route (example-route) under consumer-scoped plugin (request-transformer) is not allowed\nnesting service (example-service) under consumer-scoped plugin (request-transformer) is not allowed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := sync(tc.file)
+			require.Equal(t, tc.errorExpected, err.Error())
+		})
+	}
+}
+
+func Test_Sync_Scoped_Plugins_3x(t *testing.T) {
+	runWhen(t, "kong", ">=3.0.0")
+	setup(t)
+
+	tests := []struct {
+		name          string
+		file          string
+		errorExpected string
+	}{
+		{
+			name:          "syncing route-scoped plugin with service field set",
+			file:          "testdata/sync/036-scoped-plugins-validation/3x/route-plugins.yaml",
+			errorExpected: "building state: nesting service (example-service) under route-scoped plugin (request-transformer) is not allowed",
+		},
+		{
+			name:          "syncing service-scoped plugin with route and consumer field set",
+			file:          "testdata/sync/036-scoped-plugins-validation/3x/service-plugins.yaml",
+			errorExpected: "building state: nesting consumer (foo) under service-scoped plugin plugin (request-transformer) is not allowed\nnesting route (example-route) under service-scoped plugin (request-transformer) is not allowed",
+		},
+		{
+			name:          "syncing consumer-scoped plugin with service and route field set",
+			file:          "testdata/sync/036-scoped-plugins-validation/3x/consumer-plugins.yaml",
 			errorExpected: "building state: nesting route (example-route) under consumer-scoped plugin (request-transformer) is not allowed\nnesting service (example-service) under consumer-scoped plugin (request-transformer) is not allowed",
 		},
 	}

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/consumer-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/consumer-plugins.yaml
@@ -1,4 +1,4 @@
-_format_version: "1.0"
+_format_version: "3.0"
 services:
 - name: example-service
   port: 3200
@@ -7,10 +7,13 @@ services:
   - name: example-route
     paths:
     - ~/r1
-    plugins:
-    - name: request-transformer
-      service: example-service
-      config:
+consumers:
+- username: foo
+  plugins:
+  - name: request-transformer
+    route: example-route
+    service: example-service
+    config:
         add:
           querystring:
           - test

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/route-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/route-plugins.yaml
@@ -1,4 +1,4 @@
-_format_version: "1.0"
+_format_version: "3.0"
 services:
 - name: example-service
   port: 3200

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/service-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/service-plugins.yaml
@@ -1,4 +1,4 @@
-_format_version: "1.0"
+_format_version: "3.0"
 services:
 - name: example-service
   port: 3200

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml
@@ -1,0 +1,20 @@
+---
+_format_version: "3.0"
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  routes:
+  - name: example-route
+    paths:
+    - ~/r1
+consumers:
+- username: foo
+  plugins:
+  - name: request-transformer
+    route: example-route
+    service: example-service
+    config:
+        add:
+          querystring:
+          - test

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml
@@ -1,5 +1,4 @@
----
-_format_version: "3.0"
+_format_version: "1.0"
 services:
 - name: example-service
   port: 3200

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/route-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/route-plugins.yaml
@@ -1,0 +1,17 @@
+---
+_format_version: "3.0"
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  routes:
+  - name: example-route
+    paths:
+    - ~/r1
+    plugins:
+    - name: request-transformer
+      service: example-service
+      config:
+        add:
+          querystring:
+          - test

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/service-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/service-plugins.yaml
@@ -1,0 +1,18 @@
+---
+_format_version: "3.0"
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  plugins:
+    - name: request-transformer
+      route: example-route
+      consumer: foo
+      config:
+        add:
+          querystring:
+          - test
+  routes:
+  - name: example-route
+    paths:
+    - ~/r1


### PR DESCRIPTION
As of now, while using deck to create a
route-scoped plugin with a `service` field
defined, the sync goes through the first
time but errors out subsequently. Under a
route, we do not want the user to add the
`service` field for a plugin. Thus, we are
checking for this specific scenario and
erroring out, instead of letting the sync
action go through.

For: https://github.com/Kong/deck/issues/1353

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
