### PR TITLE
fix: strip service name from dql_routes for konnect apis

### DIFF
--- a/pkg/types/degraphql_route.go
+++ b/pkg/types/degraphql_route.go
@@ -15,12 +15,20 @@ type degraphqlRouteCRUD struct {
 	client *kong.Client
 }
 
+// kong and konnect APIs only require IDs for referenced entities.
+// konnect apis, for degraphql_routes, break if name is passed.
+func stripDegraphqlRouteReferencesName(degraphqlRoute *state.DegraphqlRoute) {
+	if degraphqlRoute.DegraphqlRoute.Service != nil && degraphqlRoute.DegraphqlRoute.Service.Name != nil {
+		degraphqlRoute.DegraphqlRoute.Service.Name = nil
+	}
+}
+
 func degraphqlRouteFromStruct(arg crud.Event) *state.DegraphqlRoute {
 	degraphqlRoute, ok := arg.Obj.(*state.DegraphqlRoute)
 	if !ok {
 		panic("unexpected type, expected *state.DegraphqlRoute")
 	}
-
+	stripDegraphqlRouteReferencesName(degraphqlRoute)
 	return degraphqlRoute
 }
 


### PR DESCRIPTION
### Summary

Konnect APIs don't support Service.Name to perform operations
on degraphql_routes. Thus, stripping the name reference.
Currently, we do the same for routes as well.
https://github.com/Kong/go-database-reconciler/blob/main/pkg/types/route.go#L19

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
