### PR TITLE
fix: changed dql routes format to show dict for service

### DIFF
--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -400,7 +400,7 @@ func existingDegraphqlRouteState(t *testing.T) *state.KongState {
 			DegraphqlRoute: kong.DegraphqlRoute{
 				ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 				Service: &kong.Service{
-					ID: kong.String("ba54b737-38aa-49d1-87c4-64e756b0c6f9"),
+					ID: kong.String("fdfd14cc-cd69-49a0-9e23-cd3375b6c0cd"),
 				},
 				Methods: kong.StringSlice("GET"),
 				URI:     kong.String("/example"),
@@ -3897,9 +3897,11 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 						{
 							Type: kong.String("degraphql_routes"),
 							Fields: CustomEntityConfiguration{
-								"uri":     kong.String("/foo"),
-								"query":   kong.String("query { foo { bar }}"),
-								"service": kong.String("fdfd14cc-cd69-49a0-9e23-cd3375b6c0cd"),
+								"uri":   kong.String("/foo"),
+								"query": kong.String("query { foo { bar }}"),
+								"service": map[string]interface{}{
+									"id": "fdfd14cc-cd69-49a0-9e23-cd3375b6c0cd",
+								},
 							},
 						},
 					},
@@ -3928,9 +3930,11 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 						{
 							Type: kong.String("degraphql_routes"),
 							Fields: CustomEntityConfiguration{
-								"uri":     kong.String("/example"),
-								"query":   kong.String("query{ example { foo } }"),
-								"service": kong.String("ba54b737-38aa-49d1-87c4-64e756b0c6f9"),
+								"uri":   kong.String("/example"),
+								"query": kong.String("query{ example { foo } }"),
+								"service": map[string]interface{}{
+									"id": "fdfd14cc-cd69-49a0-9e23-cd3375b6c0cd",
+								},
 							},
 						},
 					},
@@ -3942,7 +3946,7 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 					{
 						ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						Service: &kong.Service{
-							ID: kong.String("ba54b737-38aa-49d1-87c4-64e756b0c6f9"),
+							ID: kong.String("fdfd14cc-cd69-49a0-9e23-cd3375b6c0cd"),
 						},
 						Methods: kong.StringSlice("GET"),
 						URI:     kong.String("/example"),
@@ -3974,7 +3978,9 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 		        								author
 		      								}
 										}`),
-								"service": kong.String("foo"),
+								"service": map[string]interface{}{
+									"name": "foo",
+								},
 								"methods": kong.StringSlice("GET", "POST"),
 							},
 						},
@@ -3987,7 +3993,7 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 					{
 						ID: kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
 						Service: &kong.Service{
-							ID: kong.String("foo"),
+							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
 						Methods: kong.StringSlice("GET", "POST"),
 						URI:     kong.String("/foo"),
@@ -4028,21 +4034,37 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 			name: "handles multiple degraphql routes",
 			fields: fields{
 				targetContent: &Content{
+					Services: []FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("service1"),
+							},
+						},
+						{
+							Service: kong.Service{
+								Name: kong.String("service2"),
+							},
+						},
+					},
 					CustomEntities: []FCustomEntity{
 						{
 							Type: kong.String("degraphql_routes"),
 							Fields: CustomEntityConfiguration{
-								"uri":     kong.String("/foo"),
-								"query":   kong.String("query { foo }"),
-								"service": kong.String("service1"),
+								"uri":   kong.String("/foo"),
+								"query": kong.String("query { foo }"),
+								"service": map[string]interface{}{
+									"name": "service1",
+								},
 							},
 						},
 						{
 							Type: kong.String("degraphql_routes"),
 							Fields: CustomEntityConfiguration{
-								"uri":     kong.String("/bar"),
-								"query":   kong.String("query { bar }"),
-								"service": kong.String("service2"),
+								"uri":   kong.String("/bar"),
+								"query": kong.String("query { bar }"),
+								"service": map[string]interface{}{
+									"name": "service2",
+								},
 								"methods": kong.StringSlice("POST", "PUT"),
 							},
 						},
@@ -4053,22 +4075,40 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 			want: &utils.KongRawState{
 				DegraphqlRoutes: []*kong.DegraphqlRoute{
 					{
-						ID:    kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
+						ID:    kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
 						URI:   kong.String("/foo"),
 						Query: kong.String("query { foo }"),
 						Service: &kong.Service{
-							ID: kong.String("service1"),
+							ID: kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
 						},
 						Methods: kong.StringSlice("GET"),
 					},
 					{
-						ID:    kong.String("083f61d3-75bc-42b4-9df4-f91929e18fda"),
+						ID:    kong.String("ba843ee8-d63e-4c4f-be1c-ebea546d8fac"),
 						URI:   kong.String("/bar"),
 						Query: kong.String("query { bar }"),
 						Service: &kong.Service{
-							ID: kong.String("service2"),
+							ID: kong.String("083f61d3-75bc-42b4-9df4-f91929e18fda"),
 						},
 						Methods: kong.StringSlice("POST", "PUT"),
+					},
+				},
+				Services: []*kong.Service{
+					{
+						ID:             kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
+						Name:           kong.String("service1"),
+						Protocol:       kong.String("http"),
+						ConnectTimeout: kong.Int(60000),
+						WriteTimeout:   kong.Int(60000),
+						ReadTimeout:    kong.Int(60000),
+					},
+					{
+						ID:             kong.String("083f61d3-75bc-42b4-9df4-f91929e18fda"),
+						Name:           kong.String("service2"),
+						Protocol:       kong.String("http"),
+						ConnectTimeout: kong.Int(60000),
+						WriteTimeout:   kong.Int(60000),
+						ReadTimeout:    kong.Int(60000),
 					},
 				},
 			},

--- a/pkg/file/types.go
+++ b/pkg/file/types.go
@@ -1024,23 +1024,45 @@ func copyToFCustomEntity(dRoute map[string]interface{}, fcEntity *FCustomEntity)
 	}
 
 	fcEntity.Fields = make(map[string]interface{})
-	dRouteFields := dRoute["fields"].(map[string]interface{})
+
+	f, ok := dRoute["fields"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("fields field should be a map")
+	}
+	dRouteFields := f
 
 	if dRouteFields["service"] != nil {
-		fcEntity.Fields["service"] = dRouteFields["service"].(map[string]interface{})
+		service, ok := dRouteFields["service"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("service field should be a map")
+		}
+		fcEntity.Fields["service"] = service
 	}
 
 	if dRouteFields["uri"] != nil {
-		fcEntity.Fields["uri"] = kong.String(dRouteFields["uri"].(string))
+		uri, ok := dRouteFields["uri"].(string)
+		if !ok {
+			return fmt.Errorf("uri field should be a string")
+		}
+		fcEntity.Fields["uri"] = kong.String(uri)
 	}
 
 	if dRouteFields["query"] != nil {
-		fcEntity.Fields["query"] = kong.String(dRouteFields["query"].(string))
+		query, ok := dRouteFields["query"].(string)
+		if !ok {
+			return fmt.Errorf("query field should be a string")
+		}
+		fcEntity.Fields["query"] = kong.String(query)
 	}
 
 	if dRouteFields["methods"] != nil {
-		methods := make([]string, len(dRouteFields["methods"].([]interface{})))
-		for i, method := range dRouteFields["methods"].([]interface{}) {
+		methodsArray, ok := dRouteFields["methods"].([]interface{})
+		if !ok {
+			return fmt.Errorf("methods field should be an array")
+		}
+		methods := make([]string, len(methodsArray))
+
+		for i, method := range methodsArray {
 			methods[i] = method.(string)
 		}
 		fcEntity.Fields["methods"] = kong.StringSlice(methods...)

--- a/pkg/file/types.go
+++ b/pkg/file/types.go
@@ -991,7 +991,10 @@ func copyFromDegraphqlRoute(dRoute DegraphqlRoute, fcEntity *FCustomEntity) erro
 	fcEntity.Fields = make(map[string]interface{})
 
 	if dRoute.Service != nil && dRoute.Service.ID != nil {
-		fcEntity.Fields["service"] = *dRoute.Service.ID
+		serviceMap := make(map[string]interface{})
+		serviceMap["id"] = *dRoute.Service.ID
+		serviceMap["name"] = *dRoute.Service.Name
+		fcEntity.Fields["service"] = serviceMap
 	}
 
 	if dRoute.URI != nil {
@@ -1024,7 +1027,7 @@ func copyToFCustomEntity(dRoute map[string]interface{}, fcEntity *FCustomEntity)
 	dRouteFields := dRoute["fields"].(map[string]interface{})
 
 	if dRouteFields["service"] != nil {
-		fcEntity.Fields["service"] = kong.String(dRouteFields["service"].(string))
+		fcEntity.Fields["service"] = dRouteFields["service"].(map[string]interface{})
 	}
 
 	if dRouteFields["uri"] != nil {

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -7653,6 +7653,18 @@ func Test_Sync_DegraphqlRoutes(t *testing.T) {
 		expectedMethods := kong.StringSlice("POST")
 		assert.Equal(t, expectedMethods, degraphqlRoutes[0].Methods)
 	})
+
+	t.Run("create degraphql route - fails if service reference is not an object", func(t *testing.T) {
+		err := sync("testdata/sync/037-degraphql-routes/kong-wrong-svc-config.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "service field should be a map")
+	})
+
+	t.Run("create degraphql route - fails if service reference is not an object", func(t *testing.T) {
+		err := sync("testdata/sync/037-degraphql-routes/kong-wrong-svc-config.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "service field should be a map")
+	})
 }
 
 func Test_Sync_CustomEntities_Fake(t *testing.T) {

--- a/tests/integration/testdata/sync/037-degraphql-routes/kong-complex-query.yaml
+++ b/tests/integration/testdata/sync/037-degraphql-routes/kong-complex-query.yaml
@@ -32,4 +32,5 @@ custom_entities:
             author
           }
         }
-      service: svc1
+      service:
+        name: svc1

--- a/tests/integration/testdata/sync/037-degraphql-routes/kong-wrong-svc-config.yaml
+++ b/tests/integration/testdata/sync/037-degraphql-routes/kong-wrong-svc-config.yaml
@@ -1,0 +1,7 @@
+_format_version: "3.0"
+custom_entities:
+  - type: degraphql_routes
+    fields:
+      uri: "/foo"
+      query: "query{ foo { bar } }"
+      service: svc1

--- a/tests/integration/testdata/sync/037-degraphql-routes/kong.yaml
+++ b/tests/integration/testdata/sync/037-degraphql-routes/kong.yaml
@@ -23,4 +23,5 @@ custom_entities:
     fields:
       uri: "/foo"
       query: "query{ foo { bar } }"
-      service: svc1
+      service:
+        name: svc1


### PR DESCRIPTION
### Summary

While creating a degraphql-route using deck, we were specifying
service field as a string. This is different than how deck usually
handles references. So, inorder to comply with the current deck
format, we are changing the service reference to a dict.

### Full changelog

* fix: changed dql routes format to show dict for service.
* tests: fixed test files based on new dql-routes format.
* fix: added validations to ensure correct format for configs is passed.
* tests: added tests to handle for required fields/format.

### Issues resolved

Pre-req for https://github.com/Kong/deck/pull/1505

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
