### PR TITLE
fix: removed service id from dql_routes dump

### DIFF
--- a/pkg/file/types.go
+++ b/pkg/file/types.go
@@ -992,7 +992,6 @@ func copyFromDegraphqlRoute(dRoute DegraphqlRoute, fcEntity *FCustomEntity) erro
 
 	if dRoute.Service != nil && dRoute.Service.ID != nil {
 		serviceMap := make(map[string]interface{})
-		serviceMap["id"] = *dRoute.Service.ID
 		serviceMap["name"] = *dRoute.Service.Name
 		fcEntity.Fields["service"] = serviceMap
 	}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -7659,12 +7659,6 @@ func Test_Sync_DegraphqlRoutes(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "service field should be a map")
 	})
-
-	t.Run("create degraphql route - fails if service reference is not an object", func(t *testing.T) {
-		err := sync("testdata/sync/037-degraphql-routes/kong-wrong-svc-config.yaml")
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "service field should be a map")
-	})
 }
 
 func Test_Sync_CustomEntities_Fake(t *testing.T) {


### PR DESCRIPTION
### Summary

In case of a reset and re-sync, an id
field with service can lead to an error.

The PR also cleans up the duplicate
test found here: https://github.com/Kong/go-database-reconciler/pull/187#discussion_r1941023028

### Issues resolved

For https://github.com/Kong/go-database-reconciler/issues/193

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
