### PR TITLE
fix: fixed dump config to show select tags when consumer-group-policy-overrides is set

### DIFF
--- a/pkg/file/writer.go
+++ b/pkg/file/writer.go
@@ -70,8 +70,12 @@ func KongStateToContent(kongState *state.KongState, config WriteConfig) (*Conten
 	}
 
 	if config.IsConsumerGroupPolicyOverrideSet {
-		file.Info = &Info{
-			ConsumerGroupPolicyOverrides: true,
+		if file.Info == nil {
+			file.Info = &Info{
+				ConsumerGroupPolicyOverrides: true,
+			}
+		} else {
+			file.Info.ConsumerGroupPolicyOverrides = true
 		}
 	}
 


### PR DESCRIPTION
### Issues resolved

For https://github.com/Kong/deck/issues/1517


### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
