### PR TITLE
fix: fixed usage for deck oss

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -1346,7 +1346,7 @@ func GetAllCustomEntitiesWithType(
 	e := custom.NewEntityObject(custom.Type(entityType))
 	for {
 		s, nextOpt, err := client.CustomEntities.List(ctx, opt, e)
-		if kong.IsNotFoundErr(err) {
+		if kong.IsNotFoundErr(err) || kong.IsForbiddenErr(err) {
 			return entities, nil
 		}
 		if err != nil {

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -128,7 +128,6 @@ func (b *stateBuilder) build() (*utils.KongRawState, *utils.KonnectRawState, err
 	b.consumers()
 	b.plugins()
 	b.filterChains()
-	b.customEntities()
 	b.enterprise()
 
 	// konnect
@@ -1154,6 +1153,7 @@ func (b *stateBuilder) routes() {
 func (b *stateBuilder) enterprise() {
 	b.rbacRoles()
 	b.vaults()
+	b.customEntities()
 	// In Konnect, licenses are managed by Konnect cloud,
 	// so licenses should not be included running against Konnect when building Kong state from files.
 	if b.includeLicenses && !b.isKonnect {


### PR DESCRIPTION
### Summary

dump config comprised of custom-entities: degraphql_routes. Since, custom-entities are EE feature, a forbidden error from the gateway was causing OSS ops to fail

### Issues resolved

For https://github.com/Kong/deck/issues/1522

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
