### PR TITLE
feat: Adds paths information in 3.4.x compatibility warn

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1141,7 +1141,7 @@ func (b *stateBuilder) routes() {
 		}
 		for _, r := range allRoutes {
 			if utils.HasPathsWithRegex300AndAbove(r.Route) {
-				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID)
+				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID+" paths:"+*r.Route.Paths[0])
 			}
 		}
 		if len(unsupportedRoutes) > 0 {

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1141,7 +1141,12 @@ func (b *stateBuilder) routes() {
 		}
 		for _, r := range allRoutes {
 			if utils.HasPathsWithRegex300AndAbove(r.Route) {
-				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID+" paths:"+*r.Route.Paths[0])
+				var unsupportedPaths []string
+				for _, p := range r.Route.Paths {
+					unsupportedPaths = append(unsupportedPaths,*p)
+				}
+				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID +"\n paths:"+strings.Join(unsupportedPaths,"\n       "))
+//				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID+"\n paths:"+strings.Join(*r.Route.Paths, "\n") *r.Route.Paths[0])
 			}
 		}
 		if len(unsupportedRoutes) > 0 {

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1143,10 +1143,9 @@ func (b *stateBuilder) routes() {
 			if utils.HasPathsWithRegex300AndAbove(r.Route) {
 				var unsupportedPaths []string
 				for _, p := range r.Route.Paths {
-					unsupportedPaths = append(unsupportedPaths,*p)
+					unsupportedPaths = append(unsupportedPaths, *p)
 				}
-				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID +"\n paths:"+strings.Join(unsupportedPaths,"\n       "))
-//				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID+"\n paths:"+strings.Join(*r.Route.Paths, "\n") *r.Route.Paths[0])
+				unsupportedRoutes = append(unsupportedRoutes, *r.Route.ID+"\n paths:"+strings.Join(unsupportedPaths, "\n       "))
 			}
 		}
 		if len(unsupportedRoutes) > 0 {


### PR DESCRIPTION
### Summary
REopen from previous [PR](https://github.com/Kong/go-database-reconciler/pull/144) as some bug happened with the fork

When running `deck diff` on Kong 3.4.x we can see below error: 

```
1 unsupported routes' paths format with Kong version 3.0
or above were detected. Some of these routes are (not an exhaustive list):

ecf1297e-95e2-4e86-9384-86c892f941a7

Please upgrade your configuration to account for 3.0
breaking changes using the following command:
```
As there are hundred of regex route and the error causing the pipeline to stop. There are no way currently to determine the problematic route.

There is a workaround for this issue by running `deck convert` but I would like to see the affected route first before running the command.

### Full changelog

* Add extra path information in 3.4.x compatibility warn


### Testing

- [ ] Unit tests
- [ ] E2E tests
- [X] Manual testing on Universal
- [ ] Manual testing on Kubernetes
