### PR TITLE
ci: add testifylint to golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,7 @@ linters:
   - unparam
   - wastedassign
   - errorlint
+  - testifylint
 issues:
   max-same-issues: 0
   exclude-rules:
@@ -82,3 +83,5 @@ linters-settings:
       - golang.org/x/net/context:
           recommendations:
           - context
+  testifylint:
+    enable-all: true

--- a/pkg/crud/registry_test.go
+++ b/pkg/crud/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testActionFixture struct {
@@ -42,18 +43,17 @@ func (t testActionFixture) Update(_ context.Context, input ...Arg) (Arg, error) 
 }
 
 func TestRegistryRegister(t *testing.T) {
-	assert := assert.New(t)
 	var r Registry
 	var a Actions = newTestActionFixture("yolo")
 
 	err := r.Register("", nil)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = r.Register("foo", a)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = r.Register("foo", a)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestRegistryMustRegister(t *testing.T) {
@@ -80,18 +80,18 @@ func TestRegistryGet(t *testing.T) {
 	var a Actions = newTestActionFixture("foo")
 
 	err := r.Register("foo", a)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	a, err = r.Get("foo")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(a)
 
 	a, err = r.Get("bar")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(a)
 
 	a, err = r.Get("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(a)
 }
 
@@ -101,10 +101,10 @@ func TestRegistryCreate(t *testing.T) {
 	var a Actions = newTestActionFixture("foo")
 
 	err := r.Register("foo", a)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := r.Create(context.Background(), "foo", "yolo")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok := res.(string)
 	assert.True(ok)
@@ -112,18 +112,18 @@ func TestRegistryCreate(t *testing.T) {
 
 	// make sure it takes multiple arguments
 	res, err = r.Create(context.Background(), "foo", "yolo", "always")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok = res.(string)
 	assert.True(ok)
 	assert.Equal("foo create yolo always", result)
 
 	res, err = r.Create(context.Background(), "foo", 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = r.Create(context.Background(), "bar", 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -133,10 +133,10 @@ func TestRegistryUpdate(t *testing.T) {
 	var a Actions = newTestActionFixture("foo")
 
 	err := r.Register("foo", a)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := r.Update(context.Background(), "foo", "yolo")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok := res.(string)
 	assert.True(ok)
@@ -144,18 +144,18 @@ func TestRegistryUpdate(t *testing.T) {
 
 	// make sure it takes multiple arguments
 	res, err = r.Update(context.Background(), "foo", "yolo", "always")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok = res.(string)
 	assert.True(ok)
 	assert.Equal("foo update yolo always", result)
 
 	res, err = r.Update(context.Background(), "foo", 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = r.Update(context.Background(), "bar", 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -165,10 +165,10 @@ func TestRegistryDelete(t *testing.T) {
 	var a Actions = newTestActionFixture("foo")
 
 	err := r.Register("foo", a)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := r.Delete(context.Background(), "foo", "yolo")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok := res.(string)
 	assert.True(ok)
@@ -176,18 +176,18 @@ func TestRegistryDelete(t *testing.T) {
 
 	// make sure it takes multiple arguments
 	res, err = r.Delete(context.Background(), "foo", "yolo", "always")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok = res.(string)
 	assert.True(ok)
 	assert.Equal("foo delete yolo always", result)
 
 	res, err = r.Delete(context.Background(), "foo", 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = r.Delete(context.Background(), "bar", 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -197,10 +197,10 @@ func TestRegistryDo(t *testing.T) {
 	var a Actions = newTestActionFixture("foo")
 
 	err := r.Register("foo", a)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := r.Do(context.Background(), "foo", Create, "yolo")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok := res.(string)
 	assert.True(ok)
@@ -208,21 +208,21 @@ func TestRegistryDo(t *testing.T) {
 
 	// make sure it takes multiple arguments
 	res, err = r.Do(context.Background(), "foo", Update, "yolo", "always")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	result, ok = res.(string)
 	assert.True(ok)
 	assert.Equal("foo update yolo always", result)
 
 	res, err = r.Do(context.Background(), "foo", Delete, 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = r.Do(context.Background(), "foo", Op{"unknown-op"}, 42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = r.Do(context.Background(), "bar", Create, "yolo")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -3668,7 +3668,7 @@ func Test_stateBuilder_ingestRouteKonnectTraditionalRoute(t *testing.T) {
 				// Not checking ID equality, as it is unnecessary for testing functionality
 				b.rawState.Routes[0].ID = nil
 
-				assert.Equal(b.rawState, tt.wantState)
+				assert.Equal(tt.wantState, b.rawState)
 				assert.NotNil(b.rawState.Routes[0].RegexPriority, "RegexPriority should not be nil")
 			})
 		}
@@ -4196,7 +4196,7 @@ func Test_stateBuilder_ingestCustomEntities(t *testing.T) {
 			_, _, err := b.build()
 			if tt.wantErr {
 				require.Error(t, err, "build error was expected")
-				assert.ErrorContains(t, err, tt.errString)
+				require.ErrorContains(t, err, tt.errString)
 				assert.Equal(t, tt.want, b.rawState)
 				return
 			}

--- a/pkg/file/reader_test.go
+++ b/pkg/file/reader_test.go
@@ -70,7 +70,7 @@ func TestReadKongStateFromStdinFailsToParseText(t *testing.T) {
 	os.Stdin = tmpfile
 
 	c, err := GetContentFromFiles(filenames, false)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(c)
 }
 
@@ -142,7 +142,7 @@ func TestReadKongStateFromStdin(t *testing.T) {
 
 	c, err := GetContentFromFiles(filenames, false)
 	assert.NotNil(c)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	assert.Equal(kong.Service{
 		Name: kong.String("test service"),
@@ -157,7 +157,7 @@ func TestReadKongStateFromFile(t *testing.T) {
 
 	c, err := GetContentFromFiles(filenames, false)
 	require.NotNil(t, c)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("enabled field for service is read", func(t *testing.T) {
 		assert.Equal(t, kong.Service{

--- a/pkg/file/types_test.go
+++ b/pkg/file/types_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
 
@@ -329,9 +330,8 @@ func Test_sortKey(t *testing.T) {
 
 func TestPluginUnmarshalYAML(t *testing.T) {
 	var p FPlugin
-	assert := assert.New(t)
-	assert.Nil(yaml.Unmarshal([]byte(yamlString), &p))
-	assert.Equal(kong.Plugin{
+	require.NoError(t, yaml.Unmarshal([]byte(yamlString), &p))
+	assert.Equal(t, kong.Plugin{
 		Name:      p.Name,
 		Config:    p.Config,
 		Enabled:   p.Enabled,
@@ -351,9 +351,8 @@ func TestPluginUnmarshalYAML(t *testing.T) {
 
 func TestPluginUnmarshalJSON(t *testing.T) {
 	var p FPlugin
-	assert := assert.New(t)
-	assert.Nil(json.Unmarshal([]byte(jsonString), &p))
-	assert.Equal(kong.Plugin{
+	require.NoError(t, json.Unmarshal([]byte(jsonString), &p))
+	assert.Equal(t, kong.Plugin{
 		Name:      p.Name,
 		Config:    p.Config,
 		Enabled:   p.Enabled,
@@ -391,7 +390,7 @@ func TestFilterChainUnmarshalJSON(t *testing.T) {
 }`
 
 	assert := assert.New(t)
-	assert.Nil(json.Unmarshal([]byte(fcJSON), &fc))
+	require.NoError(t, json.Unmarshal([]byte(fcJSON), &fc))
 	assert.Equal(kong.FilterChain{
 		Name:    kong.String("my-filter-chain"),
 		ID:      kong.String("fa7bd007-e0c6-4ef2-b254-e60d3a341b0c"),
@@ -426,7 +425,7 @@ filters:
 `
 
 	assert := assert.New(t)
-	assert.Nil(yaml.Unmarshal([]byte(fcYaml), &fc))
+	require.NoError(t, yaml.Unmarshal([]byte(fcYaml), &fc))
 	assert.Equal(kong.FilterChain{
 		Name:    kong.String("my-filter-chain"),
 		ID:      kong.String("fa7bd007-e0c6-4ef2-b254-e60d3a341b0c"),

--- a/pkg/file/writer_test.go
+++ b/pkg/file/writer_test.go
@@ -431,7 +431,7 @@ func Test_getFormatVersion(t *testing.T) {
 				t.Errorf("got error = %v, expected error = %v", err, tt.wantErr)
 			}
 			if tt.expectedErr != "" {
-				assert.Equal(t, err.Error(), tt.expectedErr)
+				assert.Equal(t, tt.expectedErr, err.Error())
 			}
 			if res != tt.expected {
 				t.Errorf("Expected %v, but isn't: %v", tt.expected, res)

--- a/pkg/konnect/login_service_test.go
+++ b/pkg/konnect/login_service_test.go
@@ -102,10 +102,14 @@ func TestAuthService_OrgUserInfo(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 
 			resp, err := json.Marshal(expectedResp)
-			require.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 
 			_, err = w.Write(resp)
-			require.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 
 			return
 		}

--- a/pkg/state/aclgroup_test.go
+++ b/pkg/state/aclgroup_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func aclGroupsCollection() *ACLGroupsCollection {
@@ -12,16 +13,15 @@ func aclGroupsCollection() *ACLGroupsCollection {
 }
 
 func TestACLGroupInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := aclGroupsCollection()
 
 	var aclGroup ACLGroup
-	assert.NotNil(collection.Add(aclGroup))
+	require.Error(t, collection.Add(aclGroup))
 
 	aclGroup.Group = kong.String("my-group")
 	aclGroup.ID = kong.String("first")
 	err := collection.Add(aclGroup)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	var aclGroup2 ACLGroup
 	aclGroup2.Group = kong.String("my-group")
@@ -30,23 +30,23 @@ func TestACLGroupInsert(t *testing.T) {
 		ID: kong.String("consumer-id"),
 	}
 	err = collection.Add(aclGroup2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	// re-insert
 	err = collection.Add(aclGroup2)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	// re-insert with a different ID
 	aclGroup2.ID = kong.String("second")
 	err = collection.Add(aclGroup2)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	// re-insert for different consumer
 	aclGroup2.Consumer = &kong.Consumer{
 		ID: kong.String("consumer2-id"),
 	}
 	err = collection.Add(aclGroup2)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func TestACLGroupGetByID(t *testing.T) {
@@ -61,19 +61,19 @@ func TestACLGroupGetByID(t *testing.T) {
 	}
 
 	err := collection.Add(aclGroup)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.GetByID("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-group", *res.Group)
 
 	res, err = collection.GetByID("my-group")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.GetByID("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -81,18 +81,18 @@ func TestACLGroupGet(t *testing.T) {
 	assert := assert.New(t)
 	collection := aclGroupsCollection()
 
-	populateWithACLGroupFixtures(assert, collection)
+	populateWithACLGroupFixtures(t, collection)
 
 	res, err := collection.Get("first", "does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.Get("does-not-exist", "my-group12")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.Get("consumer1-id", "my-group12")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 }
 
@@ -108,23 +108,23 @@ func TestACLGroupUpdate(t *testing.T) {
 	}
 
 	err := collection.Add(aclGroup)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("consumer1-id", "first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-group", *res.Group)
 
 	res.Group = kong.String("my-group2")
 	err = collection.Update(*res)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("consumer1-id", "my-group")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.Get("consumer1-id", "my-group2")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("first", *res.ID)
 }
 
@@ -139,50 +139,49 @@ func TestACLGroupDelete(t *testing.T) {
 		ID: kong.String("consumer1-id"),
 	}
 	err := collection.Add(aclGroup)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("consumer1-id", "my-group1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 
 	err = collection.Delete(*res.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("consumer1-id", "my-group1")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	// delete a non-existing one
 	err = collection.Delete("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete("my-group1")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestACLGroupGetAll(t *testing.T) {
-	assert := assert.New(t)
 	collection := aclGroupsCollection()
 
-	populateWithACLGroupFixtures(assert, collection)
+	populateWithACLGroupFixtures(t, collection)
 
 	aclGroups, err := collection.GetAll()
-	assert.Nil(err)
-	assert.Equal(5, len(aclGroups))
+	require.NoError(t, err)
+	require.Len(t, aclGroups, 5)
 }
 
 func TestACLGroupGetByConsumer(t *testing.T) {
-	assert := assert.New(t)
 	collection := aclGroupsCollection()
 
-	populateWithACLGroupFixtures(assert, collection)
+	populateWithACLGroupFixtures(t, collection)
 
 	aclGroups, err := collection.GetAllByConsumerID("consumer1-id")
-	assert.Nil(err)
-	assert.Equal(3, len(aclGroups))
+	require.NoError(t, err)
+	require.Len(t, aclGroups, 3)
 }
 
-func populateWithACLGroupFixtures(assert *assert.Assertions,
+func populateWithACLGroupFixtures(
+	t *testing.T,
 	collection *ACLGroupsCollection,
 ) {
 	aclGroups := []ACLGroup{
@@ -235,6 +234,6 @@ func populateWithACLGroupFixtures(assert *assert.Assertions,
 
 	for _, k := range aclGroups {
 		err := collection.Add(k)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/state/basicauth_test.go
+++ b/pkg/state/basicauth_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func basicAuthsCollection() *BasicAuthsCollection {
@@ -12,17 +13,16 @@ func basicAuthsCollection() *BasicAuthsCollection {
 }
 
 func TestBasicAuthInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := basicAuthsCollection()
 
 	var basicAuth BasicAuth
 	basicAuth.ID = kong.String("first")
 	err := collection.Add(basicAuth)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	basicAuth.Username = kong.String("my-username")
 	err = collection.Add(basicAuth)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	var basicAuth2 BasicAuth
 	basicAuth2.Username = kong.String("my-username")
@@ -32,7 +32,7 @@ func TestBasicAuthInsert(t *testing.T) {
 		Username: kong.String("my-username"),
 	}
 	err = collection.Add(basicAuth2)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func TestBasicAuthGet(t *testing.T) {
@@ -48,21 +48,21 @@ func TestBasicAuthGet(t *testing.T) {
 	}
 
 	err := collection.Add(basicAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-username", *res.Username)
 
 	res, err = collection.Get("my-username")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("first", *res.ID)
 	assert.Equal("consumer1-id", *res.Consumer.ID)
 
 	res, err = collection.Get("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -79,24 +79,24 @@ func TestBasicAuthUpdate(t *testing.T) {
 	}
 
 	err := collection.Add(basicAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-username", *res.Username)
 
 	res.Username = kong.String("my-username2")
 	res.Password = kong.String("password")
 	err = collection.Update(*res)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-username")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.Get("my-username2")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("first", *res.ID)
 	assert.Equal("password", *res.Password)
 }
@@ -113,50 +113,49 @@ func TestBasicAuthDelete(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 	err := collection.Add(basicAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("my-username1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 
 	err = collection.Delete(*res.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-username1")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	// delete a non-existing one
 	err = collection.Delete("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete("my-username1")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestBasicAuthGetAll(t *testing.T) {
-	assert := assert.New(t)
 	collection := basicAuthsCollection()
 
-	populateWithBasicAuthFixtures(assert, collection)
+	populateWithBasicAuthFixtures(t, collection)
 
 	basicAuths, err := collection.GetAll()
-	assert.Nil(err)
-	assert.Equal(5, len(basicAuths))
+	require.NoError(t, err)
+	require.Len(t, basicAuths, 5)
 }
 
 func TestBasicAuthGetByConsumer(t *testing.T) {
-	assert := assert.New(t)
 	collection := basicAuthsCollection()
 
-	populateWithBasicAuthFixtures(assert, collection)
+	populateWithBasicAuthFixtures(t, collection)
 
 	basicAuths, err := collection.GetAllByConsumerID("consumer1-id")
-	assert.Nil(err)
-	assert.Equal(3, len(basicAuths))
+	require.NoError(t, err)
+	require.Len(t, basicAuths, 3)
 }
 
-func populateWithBasicAuthFixtures(assert *assert.Assertions,
+func populateWithBasicAuthFixtures(
+	t *testing.T,
 	collection *BasicAuthsCollection,
 ) {
 	basicAuths := []BasicAuth{
@@ -214,6 +213,6 @@ func populateWithBasicAuthFixtures(assert *assert.Assertions,
 
 	for _, k := range basicAuths {
 		err := collection.Add(k)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/state/cacert_test.go
+++ b/pkg/state/cacert_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func caCertsCollection() *CACertificatesCollection {
@@ -12,18 +13,17 @@ func caCertsCollection() *CACertificatesCollection {
 }
 
 func TestCACertificateInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := caCertsCollection()
 
 	var caCert CACertificate
-	assert.NotNil(collection.Add(caCert))
+	require.Error(t, collection.Add(caCert))
 	caCert.ID = kong.String("first")
-	assert.NotNil(collection.Add(caCert))
+	require.Error(t, collection.Add(caCert))
 	caCert.Cert = kong.String("firstCert")
-	assert.Nil(collection.Add(caCert))
+	require.NoError(t, collection.Add(caCert))
 
 	// re-inesrt
-	assert.NotNil(collection.Add(caCert))
+	require.Error(t, collection.Add(caCert))
 }
 
 func TestCACertificateGetUpdate(t *testing.T) {
@@ -32,28 +32,28 @@ func TestCACertificateGetUpdate(t *testing.T) {
 
 	var caCert CACertificate
 
-	assert.NotNil(collection.Update(caCert))
+	require.Error(t, collection.Update(caCert))
 
 	caCert.Cert = kong.String("firstCert")
 	caCert.ID = kong.String("first")
-	assert.NotNil(collection.Update(caCert))
+	require.Error(t, collection.Update(caCert))
 
 	err := collection.Add(caCert)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err := collection.Get("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(se)
 
 	se, err = collection.Get("firstCert")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	se.Cert = kong.String("firstCert-updated")
 	err = collection.Update(*se)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err = collection.Get("firstCert-updated")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	assert.Equal("firstCert-updated", *se.Cert)
 
@@ -85,40 +85,40 @@ func TestCACertificateDelete(t *testing.T) {
 	assert := assert.New(t)
 	collection := caCertsCollection()
 
-	assert.NotNil(collection.Delete(""))
+	require.Error(t, collection.Delete(""))
 
 	var caCert CACertificate
 	caCert.ID = kong.String("first")
 	caCert.Cert = kong.String("firstCert")
 	err := collection.Add(caCert)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	assert.Equal("firstCert", *se.Cert)
 
 	err = collection.Delete(*se.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete(*se.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	caCert.ID = kong.String("first")
 	caCert.Cert = kong.String("firstCert")
 	err = collection.Add(caCert)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err = collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	assert.Equal("firstCert", *se.Cert)
 
 	err = collection.Delete(*se.Cert)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete(*se.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestCACertificateGetAll(t *testing.T) {
@@ -129,16 +129,16 @@ func TestCACertificateGetAll(t *testing.T) {
 	caCert.ID = kong.String("first")
 	caCert.Cert = kong.String("firstCert")
 	err := collection.Add(caCert)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	var certificate2 CACertificate
 	certificate2.ID = kong.String("second")
 	certificate2.Cert = kong.String("secondCert")
 	err = collection.Add(certificate2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	certificates, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(certificates))
+	require.NoError(t, err)
+	assert.Len(certificates, 2)
 }

--- a/pkg/state/consumer_group_test.go
+++ b/pkg/state/consumer_group_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/kong/go-kong/kong"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,25 +16,24 @@ func TestConsumerGroupInsert(t *testing.T) {
 
 	var cg ConsumerGroup
 
-	require.NotNil(t, collection.Add(cg))
+	require.Error(t, collection.Add(cg))
 
 	cg.ID = kong.String("my-id")
 	cg.Name = kong.String("first")
 	require.NoError(t, collection.Add(cg))
 
 	// re-insert
-	require.NotNil(t, collection.Add(cg))
+	require.Error(t, collection.Add(cg))
 }
 
 func TestConsumerGroupInsertIgnoreDuplicate(t *testing.T) {
-	assert := assert.New(t)
 	collection := consumerGroupsCollection()
 
 	var cg ConsumerGroup
 	cg.ID = kong.String("my-id")
 	cg.Name = kong.String("first")
 	err := collection.Add(cg)
-	assert.Nil(err)
+	require.NoError(t, err)
 	err = collection.AddIgnoringDuplicates(cg)
-	assert.Nil(err)
+	require.NoError(t, err)
 }

--- a/pkg/state/consumer_test.go
+++ b/pkg/state/consumer_test.go
@@ -13,19 +13,18 @@ func consumersCollection() *ConsumersCollection {
 }
 
 func TestConsumerInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := consumersCollection()
 
 	var consumer Consumer
 
-	assert.NotNil(collection.Add(consumer))
+	require.Error(t, collection.Add(consumer))
 
 	consumer.ID = kong.String("first")
-	assert.Nil(collection.Add(consumer))
+	require.NoError(t, collection.Add(consumer))
 
 	// re-insert
 	consumer.Username = kong.String("my-name")
-	assert.NotNil(collection.Add(consumer))
+	require.Error(t, collection.Add(consumer))
 }
 
 func TestConsumerInsertIgnoreDuplicateUsername(t *testing.T) {
@@ -60,33 +59,33 @@ func TestConsumerGetUpdate(t *testing.T) {
 	consumer.ID = kong.String("first")
 	consumer.Username = kong.String("my-name")
 	err := collection.Add(consumer)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	c, err := collection.GetByIDOrUsername("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(c)
 
 	c, err = collection.GetByIDOrUsername("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(c)
 
 	c.ID = nil
 	c.Username = kong.String("my-updated-name")
 	err = collection.Update(*c)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	c.ID = kong.String("does-not-exist")
-	assert.NotNil(collection.Update(*c))
+	require.Error(t, collection.Update(*c))
 
 	c.ID = kong.String("first")
-	assert.Nil(collection.Update(*c))
+	require.NoError(t, collection.Update(*c))
 
 	c, err = collection.GetByIDOrUsername("my-name")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(c)
 
 	c, err = collection.GetByIDOrUsername("my-updated-name")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(c)
 }
 
@@ -100,15 +99,15 @@ func TestConsumerGetMemoryReference(t *testing.T) {
 	consumer.ID = kong.String("first")
 	consumer.Username = kong.String("my-name")
 	err := collection.Add(consumer)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	c, err := collection.GetByIDOrUsername("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(c)
 	c.Username = kong.String("update-should-not-reflect")
 
 	c, err = collection.GetByIDOrUsername("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("my-name", *c.Username)
 }
 
@@ -121,7 +120,7 @@ func TestConsumersInvalidType(t *testing.T) {
 	c.Username = kong.String("my-name")
 	c.ID = kong.String("first")
 	txn := collection.db.Txn(true)
-	assert.Nil(txn.Insert(consumerTableName, &c))
+	require.NoError(t, txn.Insert(consumerTableName, &c))
 	txn.Commit()
 
 	assert.Panics(func() {
@@ -140,21 +139,21 @@ func TestConsumerDelete(t *testing.T) {
 	consumer.ID = kong.String("first")
 	consumer.Username = kong.String("my-consumer")
 	err := collection.Add(consumer)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	c, err := collection.GetByIDOrUsername("my-consumer")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(c)
 	assert.Equal("first", *c.ID)
 
 	err = collection.Delete("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete(*c.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestConsumerGetAll(t *testing.T) {
@@ -176,11 +175,11 @@ func TestConsumerGetAll(t *testing.T) {
 		},
 	}
 	for _, s := range consumers {
-		assert.Nil(collection.Add(s))
+		require.NoError(t, collection.Add(s))
 	}
 
 	allConsumers, err := collection.GetAll()
 
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(len(consumers), len(allConsumers))
 }

--- a/pkg/state/degraphql_route_test.go
+++ b/pkg/state/degraphql_route_test.go
@@ -217,7 +217,7 @@ func TestDegraphqlRouteGetAll(t *testing.T) {
 
 	degraphqlRoutes, err := collection.GetAll()
 	require.NoError(err, "error getting all degraphql routes")
-	assert.Equal(5, len(degraphqlRoutes))
+	assert.Len(degraphqlRoutes, 5)
 	assert.IsType([]*DegraphqlRoute{}, degraphqlRoutes)
 }
 

--- a/pkg/state/document_test.go
+++ b/pkg/state/document_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kong/go-database-reconciler/pkg/konnect"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func documentCollection() *DocumentsCollection {
@@ -329,17 +330,17 @@ func TestDocumentDeleteByParent(t *testing.T) {
 		ID: kong.String("package-id1"),
 	}
 	err := collection.Add(document)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.GetByParent(document.Parent, "my-document")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 
 	err = collection.DeleteByParent(document.Parent, *re.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.DeleteByParent(document.Parent, *re.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestDocumentGetAll(t *testing.T) {
@@ -353,7 +354,7 @@ func TestDocumentGetAll(t *testing.T) {
 		ID: kong.String("id1"),
 	}
 	err := collection.Add(d1)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	var d2 Document
 	d2.Path = kong.String("my-d2")
@@ -362,12 +363,12 @@ func TestDocumentGetAll(t *testing.T) {
 		ID: kong.String("id1"),
 	}
 	err = collection.Add(d2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	documents, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(documents))
+	require.NoError(t, err)
+	assert.Len(documents, 2)
 }
 
 func TestDocumentGetAllByParent(t *testing.T) {
@@ -424,14 +425,14 @@ func TestDocumentGetAllByParent(t *testing.T) {
 
 	for _, document := range documents {
 		err := collection.Add(*document)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 
 	documents, err := collection.GetAllByParent(&konnect.ServicePackage{ID: kong.String("id1")})
-	assert.Nil(err)
-	assert.Equal(2, len(documents))
+	require.NoError(t, err)
+	assert.Len(documents, 2)
 
 	documents, err = collection.GetAllByParent(&konnect.ServicePackage{ID: kong.String("id2")})
-	assert.Nil(err)
-	assert.Equal(3, len(documents))
+	require.NoError(t, err)
+	assert.Len(documents, 3)
 }

--- a/pkg/state/filter_chain_test.go
+++ b/pkg/state/filter_chain_test.go
@@ -363,7 +363,7 @@ func TestFilterChainsCollection_Update(t *testing.T) {
 		require.NoError(t, k.Update(post))
 
 		updated, err := k.Get("update-id-1")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, "new-name", *updated.Name)
 	})
@@ -437,7 +437,7 @@ func TestFilterChainsCollection_Get(t *testing.T) {
 	require.NoError(t, collection.Add(filterChain))
 
 	re, err := collection.Get("get-test")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.NotNil(re.FilterChain)
 	assert.NotNil(re.FilterChain.ID)
@@ -471,7 +471,7 @@ func TestFilterChainsCollection_GetByProp(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(collection.Add(serviceChain))
+	require.NoError(t, collection.Add(serviceChain))
 
 	routeChain := FilterChain{
 		FilterChain: kong.FilterChain{
@@ -487,17 +487,17 @@ func TestFilterChainsCollection_GetByProp(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(collection.Add(routeChain))
+	require.NoError(t, collection.Add(routeChain))
 
 	re, err := collection.GetByProp("get-prop-service-id", "")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.NotNil(re.FilterChain)
 	assert.NotNil(re.FilterChain.ID)
 	assert.Equal("get-prop-service", *re.FilterChain.ID)
 
 	re, err = collection.GetByProp("", "get-prop-route-id")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.NotNil(re.FilterChain)
 	assert.NotNil(re.FilterChain.ID)
@@ -505,7 +505,7 @@ func TestFilterChainsCollection_GetByProp(t *testing.T) {
 
 	re, err = collection.GetByProp("", "")
 	assert.Nil(re)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Equal(errIDRequired, err)
 }
 
@@ -528,19 +528,19 @@ func TestFilterChainsCollection_GetAllByServiceID(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(collection.Add(serviceChain))
+	require.NoError(t, collection.Add(serviceChain))
 
 	re, err := collection.GetAllByServiceID("get-all-service-id")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal([]*FilterChain{&serviceChain}, re)
 
 	re, err = collection.GetAllByServiceID("no-chain-with-this-service-id")
-	assert.Nil(err)
-	assert.Equal(0, len(re))
+	require.NoError(t, err)
+	assert.Empty(re)
 
 	re, err = collection.GetAllByServiceID("")
 	assert.Nil(re)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Equal(errIDRequired, err)
 }
 
@@ -561,19 +561,19 @@ func TestFilterChainsCollection_GetAllByRouteID(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(collection.Add(routeChain))
+	require.NoError(t, collection.Add(routeChain))
 
 	re, err := collection.GetAllByRouteID("get-all-route-id")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal([]*FilterChain{&routeChain}, re)
 
 	re, err = collection.GetAllByRouteID("no-chain-with-this-route-id")
-	assert.Nil(err)
-	assert.Equal(0, len(re))
+	require.NoError(t, err)
+	assert.Empty(re)
 
 	re, err = collection.GetAllByRouteID("")
 	assert.Nil(re)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Equal(errIDRequired, err)
 }
 
@@ -596,14 +596,14 @@ func TestFilterChainsCollection_Delete(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(collection.Add(filterChain))
+	require.NoError(t, collection.Add(filterChain))
 
 	res, err := collection.Get("delete-test")
 	assert.NotNil(res)
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("delete-test")
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("delete-test")
 	assert.Equal(ErrNotFound, err)
@@ -634,10 +634,10 @@ func TestFilterChainsCollection_GetAll(t *testing.T) {
 			},
 		}
 
-		assert.NoError(collection.Add(filterChain))
+		require.NoError(t, collection.Add(filterChain))
 	}
 
 	allFilterChains, err := collection.GetAll()
-	assert.Nil(err)
-	assert.Equal(3, len(allFilterChains))
+	require.NoError(t, err)
+	assert.Len(allFilterChains, 3)
 }

--- a/pkg/state/hmacauth_test.go
+++ b/pkg/state/hmacauth_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func hmacAuthsCollection() *HMACAuthsCollection {
@@ -12,17 +13,16 @@ func hmacAuthsCollection() *HMACAuthsCollection {
 }
 
 func TestHMACAuthInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := hmacAuthsCollection()
 
 	var hmacAuth HMACAuth
 	hmacAuth.ID = kong.String("first")
 	err := collection.Add(hmacAuth)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	hmacAuth.Username = kong.String("my-username")
 	err = collection.Add(hmacAuth)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	var hmacAuth2 HMACAuth
 	hmacAuth2.Username = kong.String("my-username")
@@ -32,7 +32,7 @@ func TestHMACAuthInsert(t *testing.T) {
 		Username: kong.String("my-username"),
 	}
 	err = collection.Add(hmacAuth2)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func TestHMACAuthGet(t *testing.T) {
@@ -48,21 +48,21 @@ func TestHMACAuthGet(t *testing.T) {
 	}
 
 	err := collection.Add(hmacAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-username", *res.Username)
 
 	res, err = collection.Get("my-username")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("first", *res.ID)
 	assert.Equal("consumer1-id", *res.Consumer.ID)
 
 	res, err = collection.Get("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -78,24 +78,24 @@ func TestHMACAuthUpdate(t *testing.T) {
 	}
 
 	err := collection.Add(hmacAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-username", *res.Username)
 
 	res.Username = kong.String("my-username2")
 	res.Secret = kong.String("secret")
 	err = collection.Update(*res)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-username")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.Get("my-username2")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("first", *res.ID)
 	assert.Equal("secret", *res.Secret)
 }
@@ -112,50 +112,49 @@ func TestHMACAuthDelete(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 	err := collection.Add(hmacAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("my-username1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 
 	err = collection.Delete(*res.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-username1")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	// delete a non-existing one
 	err = collection.Delete("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete("my-username1")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestHMACAuthGetAll(t *testing.T) {
-	assert := assert.New(t)
 	collection := hmacAuthsCollection()
 
-	populateWithHMACAuthFixtures(assert, collection)
+	populateWithHMACAuthFixtures(t, collection)
 
 	hmacAuths, err := collection.GetAll()
-	assert.Nil(err)
-	assert.Equal(5, len(hmacAuths))
+	require.NoError(t, err)
+	require.Len(t, hmacAuths, 5)
 }
 
 func TestHMACAuthGetByConsumer(t *testing.T) {
-	assert := assert.New(t)
 	collection := hmacAuthsCollection()
 
-	populateWithHMACAuthFixtures(assert, collection)
+	populateWithHMACAuthFixtures(t, collection)
 
 	hmacAuths, err := collection.GetAllByConsumerID("consumer1-id")
-	assert.Nil(err)
-	assert.Equal(3, len(hmacAuths))
+	require.NoError(t, err)
+	require.Len(t, hmacAuths, 3)
 }
 
-func populateWithHMACAuthFixtures(assert *assert.Assertions,
+func populateWithHMACAuthFixtures(
+	t *testing.T,
 	collection *HMACAuthsCollection,
 ) {
 	hmacAuths := []HMACAuth{
@@ -213,6 +212,6 @@ func populateWithHMACAuthFixtures(assert *assert.Assertions,
 
 	for _, k := range hmacAuths {
 		err := collection.Add(k)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/state/indexers/md5Indexer_test.go
+++ b/pkg/state/indexers/md5Indexer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMD5FieldsIndexer(t *testing.T) {
@@ -27,17 +28,17 @@ func TestMD5FieldsIndexer(t *testing.T) {
 
 	ok, val, err := in.FromObject(b)
 	assert.True(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	sum := md5.Sum([]byte(s1 + s2))
 	assert.Equal(sum[:], val)
 
 	val, err = in.FromArgs(s1, s2)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(sum[:], val)
 
 	ok, val, err = in.FromObject(Foo{})
 	assert.False(ok)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Empty(val)
 
 	s1 = ""
@@ -47,14 +48,14 @@ func TestMD5FieldsIndexer(t *testing.T) {
 		Baz: &s2,
 	})
 	assert.False(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Empty(val)
 
 	val, err = in.FromArgs("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(val)
 
 	val, err = in.FromArgs(2)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(val)
 }

--- a/pkg/state/indexers/methodIndexer_test.go
+++ b/pkg/state/indexers/methodIndexer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Foo struct {
@@ -34,30 +35,30 @@ func TestMethodIndexer(t *testing.T) {
 
 	ok, val, err := in.FromObject(b)
 	assert.True(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal([]byte("id1"), val)
 
 	ok, val, err = in.FromObject(Foo{})
 	assert.False(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Empty(val)
 
 	idInterface := (ID)(b)
 	ok, val, err = in.FromObject(idInterface)
 	assert.True(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal([]byte("id1"), val)
 
 	val, err = in.FromArgs("id1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal([]byte("id1"), val)
 
 	val, err = in.FromArgs("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(val)
 
 	val, err = in.FromArgs(42)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(val)
 
 	in = &MethodIndexer{
@@ -66,6 +67,6 @@ func TestMethodIndexer(t *testing.T) {
 
 	ok, val, err = in.FromObject(Foo{id: "id1"})
 	assert.False(ok)
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Empty(val)
 }

--- a/pkg/state/indexers/subFieldIndexer_test.go
+++ b/pkg/state/indexers/subFieldIndexer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubFieldIndexer(t *testing.T) {
@@ -33,12 +34,12 @@ func TestSubFieldIndexer(t *testing.T) {
 	ok, val, err := in.FromObject(b)
 	assert := assert.New(t)
 	assert.True(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("fubar\x00", string(val))
 
 	ok, val, err = in.FromObject(Baz{})
 	assert.False(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Empty(val)
 
 	s = ""
@@ -48,20 +49,20 @@ func TestSubFieldIndexer(t *testing.T) {
 		},
 	})
 	assert.False(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Empty(val)
 
 	val, err = in.FromArgs("fubar")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("fubar\x00", string(val))
 
 	val, err = in.FromArgs(2)
 	assert.Nil(val)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	val, err = in.FromArgs("1", "2")
 	assert.Equal([]byte("12\x00"), val)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func TestSubFieldIndexerPointer(t *testing.T) {
@@ -91,10 +92,10 @@ func TestSubFieldIndexerPointer(t *testing.T) {
 	ok, val, err := in.FromObject(b)
 	assert := assert.New(t)
 	assert.True(ok)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("fubar\x00", string(val))
 
 	val, err = in.FromArgs("fubar")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("fubar\x00", string(val))
 }

--- a/pkg/state/jwtauth_test.go
+++ b/pkg/state/jwtauth_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func jwtAuthsCollection() *JWTAuthsCollection {
@@ -12,14 +13,13 @@ func jwtAuthsCollection() *JWTAuthsCollection {
 }
 
 func TestJWTAuthInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := jwtAuthsCollection()
 
 	var jwtAuth JWTAuth
 	jwtAuth.Key = kong.String("my-key")
 	jwtAuth.ID = kong.String("first")
 	err := collection.Add(jwtAuth)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	var jwtAuth2 JWTAuth
 	jwtAuth2.Key = kong.String("my-key")
@@ -29,7 +29,7 @@ func TestJWTAuthInsert(t *testing.T) {
 		Username: kong.String("my-username"),
 	}
 	err = collection.Add(jwtAuth2)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func TestJWTAuthGet(t *testing.T) {
@@ -45,21 +45,21 @@ func TestJWTAuthGet(t *testing.T) {
 	}
 
 	err := collection.Add(jwtAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-key", *res.Key)
 
 	res, err = collection.Get("my-key")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("first", *res.ID)
 	assert.Equal("consumer1-id", *res.Consumer.ID)
 
 	res, err = collection.Get("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -76,23 +76,23 @@ func TestJWTAuthUpdate(t *testing.T) {
 	}
 
 	err := collection.Add(jwtAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-key", *res.Key)
 
 	res.Key = kong.String("my-key2")
 	err = collection.Update(*res)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-key")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.Get("my-key2")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("first", *res.ID)
 }
 
@@ -108,50 +108,49 @@ func TestJWTAuthDelete(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 	err := collection.Add(jwtAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("my-key1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 
 	err = collection.Delete(*res.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-key1")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	// delete a non-existing one
 	err = collection.Delete("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete("my-key1")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestJWTAuthGetAll(t *testing.T) {
-	assert := assert.New(t)
 	collection := jwtAuthsCollection()
 
-	populateWithJWTAuthFixtures(assert, collection)
+	populateWithJWTAuthFixtures(t, collection)
 
 	jwtAuths, err := collection.GetAll()
-	assert.Nil(err)
-	assert.Equal(5, len(jwtAuths))
+	require.NoError(t, err)
+	require.Len(t, jwtAuths, 5)
 }
 
 func TestJWTAuthGetByConsumer(t *testing.T) {
-	assert := assert.New(t)
 	collection := jwtAuthsCollection()
 
-	populateWithJWTAuthFixtures(assert, collection)
+	populateWithJWTAuthFixtures(t, collection)
 
 	jwtAuths, err := collection.GetAllByConsumerID("consumer1-id")
-	assert.Nil(err)
-	assert.Equal(3, len(jwtAuths))
+	require.NoError(t, err)
+	require.Len(t, jwtAuths, 3)
 }
 
-func populateWithJWTAuthFixtures(assert *assert.Assertions,
+func populateWithJWTAuthFixtures(
+	t *testing.T,
 	collection *JWTAuthsCollection,
 ) {
 	jwtAuths := []JWTAuth{
@@ -209,6 +208,6 @@ func populateWithJWTAuthFixtures(assert *assert.Assertions,
 
 	for _, k := range jwtAuths {
 		err := collection.Add(k)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/state/license_test.go
+++ b/pkg/state/license_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var presetLicense = License{
@@ -53,13 +54,13 @@ func TestLicenseCollection_Add(t *testing.T) {
 			initialState := state()
 			c := initialState.Licenses
 			err := c.Add(presetLicense)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Add(*tc.license)
 			if tc.expectedError != nil {
-				assert.ErrorAs(t, err, &tc.expectedError)
+				assert.ErrorIs(t, err, tc.expectedError)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -94,15 +95,15 @@ func TestLicenseCollection_Get(t *testing.T) {
 			initialState := state()
 			c := initialState.Licenses
 			err := c.Add(presetLicense)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			l, err := c.Get(tc.id)
 			if tc.expectedError == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.id, *l.ID)
 				assert.Equal(t, tc.expectedPayload, *l.Payload)
 			} else {
-				assert.ErrorAs(t, err, &tc.expectedError)
+				assert.ErrorIs(t, err, tc.expectedError)
 			}
 		})
 	}
@@ -145,16 +146,16 @@ func TestLicenseCollection_Update(t *testing.T) {
 			initialState := state()
 			c := initialState.Licenses
 			err := c.Add(presetLicense)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Update(tc.license)
 			if tc.expectedError == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				updatedLicense, err := c.Get(*tc.license.ID)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, *tc.license.Payload, *updatedLicense.Payload)
 			} else {
-				assert.ErrorAs(t, err, &tc.expectedError)
+				assert.ErrorIs(t, err, tc.expectedError)
 			}
 		})
 	}
@@ -187,13 +188,13 @@ func TestLicenseCollection_Delete(t *testing.T) {
 			initialState := state()
 			c := initialState.Licenses
 			err := c.Add(presetLicense)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Delete(tc.id)
 			if tc.expectedError == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.ErrorAs(t, err, &tc.expectedError)
+				assert.ErrorIs(t, err, tc.expectedError)
 			}
 		})
 	}
@@ -203,13 +204,13 @@ func TestLicenseCollection_GetAll(t *testing.T) {
 	initialState := state()
 	c := initialState.Licenses
 	licenses, err := c.GetAll()
-	assert.NoError(t, err)
-	assert.Len(t, licenses, 0, "Should have no licenses")
+	require.NoError(t, err)
+	assert.Empty(t, licenses, "Should have no licenses")
 
 	err = c.Add(presetLicense)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	licenses, err = c.GetAll()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, licenses, 1, "Should have 1 license after adding")
 }

--- a/pkg/state/mtlsauth_test.go
+++ b/pkg/state/mtlsauth_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func mtlsAuthsCollection() *MTLSAuthsCollection {
@@ -12,17 +13,16 @@ func mtlsAuthsCollection() *MTLSAuthsCollection {
 }
 
 func TestMTLSAuthInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := mtlsAuthsCollection()
 
 	var mtlsAuth MTLSAuth
 	mtlsAuth.ID = kong.String("first")
 	err := collection.Add(mtlsAuth)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	mtlsAuth.SubjectName = kong.String("test@example.com")
 	err = collection.Add(mtlsAuth)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	var mtlsAuth2 MTLSAuth
 	mtlsAuth2.SubjectName = kong.String("test@example.com")
@@ -32,7 +32,7 @@ func TestMTLSAuthInsert(t *testing.T) {
 		Username: kong.String("my-username"),
 	}
 	err = collection.Add(mtlsAuth2)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func TestMTLSAuthGet(t *testing.T) {
@@ -48,15 +48,15 @@ func TestMTLSAuthGet(t *testing.T) {
 	}
 
 	err := collection.Add(mtlsAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("test@example.com", *res.SubjectName)
 
 	res, err = collection.Get("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -73,19 +73,19 @@ func TestMTLSAuthUpdate(t *testing.T) {
 	}
 
 	err := collection.Add(mtlsAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("test@example.com", *res.SubjectName)
 
 	res.SubjectName = kong.String("test2@example.com")
 	err = collection.Update(*res)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("test2@example.com", *res.SubjectName)
 }
 
@@ -101,47 +101,46 @@ func TestMTLSAuthDelete(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 	err := collection.Add(mtlsAuth)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 
 	err = collection.Delete(*res.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	// delete a non-existing one
 	err = collection.Delete("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestMTLSAuthGetAll(t *testing.T) {
-	assert := assert.New(t)
 	collection := mtlsAuthsCollection()
 
-	populateWithMTLSAuthFixtures(assert, collection)
+	populateWithMTLSAuthFixtures(t, collection)
 
 	mtlsAuths, err := collection.GetAll()
-	assert.Nil(err)
-	assert.Equal(5, len(mtlsAuths))
+	require.NoError(t, err)
+	require.Len(t, mtlsAuths, 5)
 }
 
 func TestMTLSAuthGetByConsumer(t *testing.T) {
-	assert := assert.New(t)
 	collection := mtlsAuthsCollection()
 
-	populateWithMTLSAuthFixtures(assert, collection)
+	populateWithMTLSAuthFixtures(t, collection)
 
 	mtlsAuths, err := collection.GetAllByConsumerID("consumer1-id")
-	assert.Nil(err)
-	assert.Equal(3, len(mtlsAuths))
+	require.NoError(t, err)
+	require.Len(t, mtlsAuths, 3)
 }
 
-func populateWithMTLSAuthFixtures(assert *assert.Assertions,
+func populateWithMTLSAuthFixtures(
+	t *testing.T,
 	collection *MTLSAuthsCollection,
 ) {
 	mtlsAuths := []MTLSAuth{
@@ -199,6 +198,6 @@ func populateWithMTLSAuthFixtures(assert *assert.Assertions,
 
 	for _, k := range mtlsAuths {
 		err := collection.Add(k)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/state/oauth2_test.go
+++ b/pkg/state/oauth2_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func oauth2CredsCollection() *Oauth2CredsCollection {
@@ -12,21 +13,20 @@ func oauth2CredsCollection() *Oauth2CredsCollection {
 }
 
 func TestOauth2CredInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := oauth2CredsCollection()
 
 	var oauth2Cred Oauth2Credential
 	oauth2Cred.ClientID = kong.String("client-id")
 	oauth2Cred.ID = kong.String("first")
 	err := collection.Add(oauth2Cred)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	oauth2Cred.Consumer = &kong.Consumer{
 		ID:       kong.String("consumer-id"),
 		Username: kong.String("my-username"),
 	}
 	err = collection.Add(oauth2Cred)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func TestOauth2CredentialGet(t *testing.T) {
@@ -42,21 +42,21 @@ func TestOauth2CredentialGet(t *testing.T) {
 	}
 
 	err := collection.Add(oauth2Cred)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-clientid", *res.ClientID)
 
 	res, err = collection.Get("my-clientid")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("first", *res.ID)
 	assert.Equal("consumer1-id", *res.Consumer.ID)
 
 	res, err = collection.Get("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 }
 
@@ -73,23 +73,23 @@ func TestOauth2CredentialUpdate(t *testing.T) {
 	}
 
 	err := collection.Add(oauth2Cred)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 	assert.Equal("my-clientid", *res.ClientID)
 
 	res.ClientID = kong.String("my-clientid2")
 	err = collection.Update(*res)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-clientid")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	res, err = collection.Get("my-clientid2")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal("first", *res.ID)
 }
 
@@ -105,50 +105,49 @@ func TestOauth2CredentialDelete(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 	err := collection.Add(oauth2Cred)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err := collection.Get("my-clientid1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(res)
 
 	err = collection.Delete(*res.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	res, err = collection.Get("my-clientid1")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(res)
 
 	// delete a non-existing one
 	err = collection.Delete("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete("my-clientid1")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestOauth2CredentialGetAll(t *testing.T) {
-	assert := assert.New(t)
 	collection := oauth2CredsCollection()
 
-	populateWithOauth2CredentialFixtures(assert, collection)
+	populateWithOauth2CredentialFixtures(t, collection)
 
 	oauth2Creds, err := collection.GetAll()
-	assert.Nil(err)
-	assert.Equal(5, len(oauth2Creds))
+	require.NoError(t, err)
+	require.Len(t, oauth2Creds, 5)
 }
 
 func TestOauth2CredentialGetByConsumer(t *testing.T) {
-	assert := assert.New(t)
 	collection := oauth2CredsCollection()
 
-	populateWithOauth2CredentialFixtures(assert, collection)
+	populateWithOauth2CredentialFixtures(t, collection)
 
 	oauth2Creds, err := collection.GetAllByConsumerID("consumer1-id")
-	assert.Nil(err)
-	assert.Equal(3, len(oauth2Creds))
+	require.NoError(t, err)
+	require.Len(t, oauth2Creds, 3)
 }
 
-func populateWithOauth2CredentialFixtures(assert *assert.Assertions,
+func populateWithOauth2CredentialFixtures(
+	t *testing.T,
 	collection *Oauth2CredsCollection,
 ) {
 	oauth2Creds := []Oauth2Credential{
@@ -206,6 +205,6 @@ func populateWithOauth2CredentialFixtures(assert *assert.Assertions,
 
 	for _, k := range oauth2Creds {
 		err := collection.Add(k)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/state/plugin_test.go
+++ b/pkg/state/plugin_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func pluginsCollection() *PluginsCollection {
@@ -313,10 +314,10 @@ func TestPluginGet(t *testing.T) {
 	assert.NotNil(plugin.Service)
 	err := collection.Add(plugin)
 	assert.NotNil(plugin.Service)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.Equal("my-plugin", *re.Name)
 	re.Service = &kong.Service{
@@ -393,39 +394,39 @@ func TestGetPluginByProp(t *testing.T) {
 	collection := pluginsCollection()
 
 	for _, p := range plugins {
-		assert.Nil(collection.Add(p))
+		require.NoError(t, collection.Add(p))
 	}
 
 	plugin, err := collection.GetByProp("", "", "", "", "")
 	assert.Nil(plugin)
-	assert.Error(err)
+	require.Error(t, err)
 
 	plugin, err = collection.GetByProp("foo", "", "", "", "")
 	assert.Nil(plugin)
 	assert.Equal(ErrNotFound, err)
 
 	plugin, err = collection.GetByProp("key-auth", "", "", "", "")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(plugin)
 	assert.Equal("value1", plugin.Config["key1"])
 
 	plugin, err = collection.GetByProp("key-auth", "svc1", "", "", "")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(plugin)
 	assert.Equal("value2", plugin.Config["key2"])
 
 	plugin, err = collection.GetByProp("key-auth", "", "route1", "", "")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(plugin)
 	assert.Equal("value3", plugin.Config["key3"])
 
 	plugin, err = collection.GetByProp("key-auth", "", "", "consumer1", "")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(plugin)
 	assert.Equal("value4", plugin.Config["key4"])
 
 	plugin, err = collection.GetByProp("key-auth", "", "", "", "cg1")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(plugin)
 	assert.Equal("value5", plugin.Config["key5"])
 }
@@ -466,20 +467,20 @@ func TestPluginDelete(t *testing.T) {
 		Name: kong.String("service1-name"),
 	}
 	err := collection.Add(plugin)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	p, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(p)
 	assert.Equal("bar", p.Config["foo"])
 
 	err = collection.Delete(*p.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete(*p.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 
-	assert.NotNil(collection.Delete(""))
+	require.Error(t, collection.Delete(""))
 }
 
 func TestPluginGetAll(t *testing.T) {
@@ -534,39 +535,39 @@ func TestPluginGetAll(t *testing.T) {
 	}
 
 	for _, p := range plugins {
-		assert.Nil(collection.Add(*p))
+		require.NoError(t, collection.Add(*p))
 	}
 
 	allPlugins, err := collection.GetAll()
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(len(plugins), len(allPlugins))
 
 	allPlugins, err = collection.GetAllByName("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(allPlugins)
 	allPlugins, err = collection.GetAllByConsumerID("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(allPlugins)
 	allPlugins, err = collection.GetAllByRouteID("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(allPlugins)
 	allPlugins, err = collection.GetAllByServiceID("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(allPlugins)
 
 	allPlugins, err = collection.GetAllByName("key-auth")
-	assert.Nil(err)
-	assert.Equal(2, len(allPlugins))
+	require.NoError(t, err)
+	assert.Len(allPlugins, 2)
 
 	allPlugins, err = collection.GetAllByRouteID("route1-id")
-	assert.Nil(err)
-	assert.Equal(2, len(allPlugins))
+	require.NoError(t, err)
+	assert.Len(allPlugins, 2)
 
 	allPlugins, err = collection.GetAllByServiceID("service1-id")
-	assert.Nil(err)
-	assert.Equal(2, len(allPlugins))
+	require.NoError(t, err)
+	assert.Len(allPlugins, 2)
 
 	allPlugins, err = collection.GetAllByServiceID("service-nope")
-	assert.Nil(err)
-	assert.Equal(0, len(allPlugins))
+	require.NoError(t, err)
+	assert.Empty(allPlugins)
 }

--- a/pkg/state/rbac_endpoint_permission_test.go
+++ b/pkg/state/rbac_endpoint_permission_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func rbacEndpointPermissionsCollection() *RBACEndpointPermissionsCollection {
@@ -237,17 +238,17 @@ func TestRBACEndpointPermissionDelete(t *testing.T) {
 	}}
 
 	err := collection.Add(rbacEndpointPermission)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get(rbacEndpointPermission.FriendlyName())
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 
 	err = collection.Delete(re.FriendlyName())
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete(re.FriendlyName())
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestRBACEndpointPermissionGetAll(t *testing.T) {
@@ -262,7 +263,7 @@ func TestRBACEndpointPermissionGetAll(t *testing.T) {
 	}}
 
 	err := collection.Add(rbacEndpointPermission)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	rbacEndpointPermission2 := RBACEndpointPermission{RBACEndpointPermission: kong.RBACEndpointPermission{
 		Workspace: kong.String("*"),
@@ -272,12 +273,12 @@ func TestRBACEndpointPermissionGetAll(t *testing.T) {
 	}}
 
 	err = collection.Add(rbacEndpointPermission2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	rbacEndpointPermissions, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(rbacEndpointPermissions))
+	require.NoError(t, err)
+	assert.Len(rbacEndpointPermissions, 2)
 }
 
 func TestRBACEndpointPermissionGetAllByServiceID(t *testing.T) {
@@ -319,14 +320,14 @@ func TestRBACEndpointPermissionGetAllByServiceID(t *testing.T) {
 
 	for _, rbacEndpointPermission := range rbacEndpointPermissions {
 		err := collection.Add(*rbacEndpointPermission)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 
 	rbacEndpointPermissions, err := collection.GetAllByRoleID("1234")
-	assert.Nil(err)
-	assert.Equal(3, len(rbacEndpointPermissions))
+	require.NoError(t, err)
+	assert.Len(rbacEndpointPermissions, 3)
 
 	rbacEndpointPermissions, err = collection.GetAllByRoleID("4321")
-	assert.Nil(err)
-	assert.Equal(2, len(rbacEndpointPermissions))
+	require.NoError(t, err)
+	assert.Len(rbacEndpointPermissions, 2)
 }

--- a/pkg/state/rbac_role_test.go
+++ b/pkg/state/rbac_role_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func rbacRolesCollection() *RBACRolesCollection {
@@ -260,17 +261,17 @@ func TestRBACRoleDelete(t *testing.T) {
 	rbacRole.ID = kong.String("first")
 
 	err := collection.Add(rbacRole)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get("my-rbacRole")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 
 	err = collection.Delete(*re.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete(*re.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestRBACRoleGetAll(t *testing.T) {
@@ -282,17 +283,17 @@ func TestRBACRoleGetAll(t *testing.T) {
 	rbacRole.ID = kong.String("first")
 
 	err := collection.Add(rbacRole)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	var rbacRole2 RBACRole
 	rbacRole2.Name = kong.String("my-rbacRole2")
 	rbacRole2.ID = kong.String("second")
 
 	err = collection.Add(rbacRole2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	rbacRoles, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(rbacRoles))
+	require.NoError(t, err)
+	assert.Len(rbacRoles, 2)
 }

--- a/pkg/state/route_test.go
+++ b/pkg/state/route_test.go
@@ -310,17 +310,17 @@ func TestRouteGetMemoryReference(t *testing.T) {
 	assert.NotNil(route.Service)
 	err := collection.Add(route)
 	assert.NotNil(route.Service)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.Equal("my-route", *re.Name)
 
 	re.SNIs = kong.StringSlice("example.com", "demo.example.com")
 
 	re, err = collection.Get("my-route")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.Nil(re.SNIs)
 }
@@ -337,18 +337,18 @@ func TestRouteDelete(t *testing.T) {
 		ID: kong.String("service1-id"),
 	}
 	err := collection.Add(route)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get("my-route")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.Equal("example.com", *re.Hosts[0])
 
 	err = collection.Delete(*re.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete(*re.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestRouteGetAll(t *testing.T) {
@@ -363,7 +363,7 @@ func TestRouteGetAll(t *testing.T) {
 		ID: kong.String("service1-id"),
 	}
 	err := collection.Add(route)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	var route2 Route
 	route2.Name = kong.String("my-route2")
@@ -373,12 +373,12 @@ func TestRouteGetAll(t *testing.T) {
 		ID: kong.String("service1-id"),
 	}
 	err = collection.Add(route2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	routes, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(routes))
+	require.NoError(t, err)
+	assert.Len(routes, 2)
 }
 
 func TestRouteGetAllByServiceID(t *testing.T) {
@@ -438,14 +438,14 @@ func TestRouteGetAllByServiceID(t *testing.T) {
 
 	for _, route := range routes {
 		err := collection.Add(*route)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 
 	routes, err := collection.GetAllByServiceID("service1-id")
-	assert.Nil(err)
-	assert.Equal(2, len(routes))
+	require.NoError(t, err)
+	assert.Len(routes, 2)
 
 	routes, err = collection.GetAllByServiceID("service2-id")
-	assert.Nil(err)
-	assert.Equal(3, len(routes))
+	require.NoError(t, err)
+	assert.Len(routes, 3)
 }

--- a/pkg/state/service_package_test.go
+++ b/pkg/state/service_package_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kong/go-database-reconciler/pkg/konnect"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func servicePackagesCollection() *ServicePackagesCollection {
@@ -261,21 +262,21 @@ func TestServicePackageUpdate(t *testing.T) {
 			Name: kong.String("foo-name"),
 		},
 	}
-	assert.Nil(k.Add(svc1))
+	require.NoError(t, k.Add(svc1))
 
 	svc1.Name = kong.String("bar-name")
-	assert.Nil(k.Update(svc1))
+	require.NoError(t, k.Update(svc1))
 
 	r, err := k.Get("foo-id")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(r)
 
 	r, err = k.Get("bar-name")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(r)
 
 	r, err = k.Get("foo-name")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(r)
 }
 
@@ -299,25 +300,24 @@ func TestServicePackagesInvalidType(t *testing.T) {
 }
 
 func TestServicePackageDelete(t *testing.T) {
-	assert := assert.New(t)
 	collection := servicePackagesCollection()
 
 	var servicePackage ServicePackage
 	servicePackage.ID = kong.String("first-id")
 	servicePackage.Name = kong.String("first-name")
 	err := collection.Add(servicePackage)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	err = collection.Delete("first-id")
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("first-name")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete("")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestServicePackageGetAll(t *testing.T) {
@@ -339,12 +339,12 @@ func TestServicePackageGetAll(t *testing.T) {
 		},
 	}
 	for _, s := range services {
-		assert.Nil(collection.Add(s))
+		require.NoError(t, collection.Add(s))
 	}
 
 	allServices, err := collection.GetAll()
 
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(len(services), len(allServices))
 }
 
@@ -372,18 +372,18 @@ func TestServicePackagesGetAllMemoryReference(t *testing.T) {
 		},
 	}
 	for _, s := range services {
-		assert.Nil(collection.Add(s))
+		require.NoError(t, collection.Add(s))
 	}
 
 	allServices, err := collection.GetAll()
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(len(services), len(allServices))
 
 	allServices[0].Description = kong.String("new-service1-desc")
 	allServices[1].Description = kong.String("new-service2-desc")
 
 	servicePackage, err := collection.Get("my-service1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(servicePackage)
 	assert.Equal("service1-desc", *servicePackage.Description)
 }

--- a/pkg/state/service_test.go
+++ b/pkg/state/service_test.go
@@ -293,21 +293,21 @@ func TestServiceUpdate(t *testing.T) {
 			Host: kong.String("example.com"),
 		},
 	}
-	assert.Nil(k.Add(svc1))
+	require.NoError(t, k.Add(svc1))
 
 	svc1.Name = kong.String("bar-name")
-	assert.Nil(k.Update(svc1))
+	require.NoError(t, k.Update(svc1))
 
 	r, err := k.Get("foo-id")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(r)
 
 	r, err = k.Get("bar-name")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(r)
 
 	r, err = k.Get("foo-name")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(r)
 }
 
@@ -322,15 +322,15 @@ func TestServiceGetMemoryReference(t *testing.T) {
 	service.Name = kong.String("my-service")
 	service.ID = kong.String("first")
 	err := collection.Add(service)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	se.Host = kong.String("example.com")
 
 	se, err = collection.Get("my-service")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	assert.Nil(se.Host)
 }
@@ -355,25 +355,24 @@ func TestServicesInvalidType(t *testing.T) {
 }
 
 func TestServiceDelete(t *testing.T) {
-	assert := assert.New(t)
 	collection := servicesCollection()
 
 	var service Service
 	service.ID = kong.String("first")
 	service.Host = kong.String("example.com")
 	err := collection.Add(service)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	err = collection.Delete("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("first")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	err = collection.Delete("")
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestServiceGetAll(t *testing.T) {
@@ -397,12 +396,12 @@ func TestServiceGetAll(t *testing.T) {
 		},
 	}
 	for _, s := range services {
-		assert.Nil(collection.Add(s))
+		require.NoError(t, collection.Add(s))
 	}
 
 	allServices, err := collection.GetAll()
 
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(len(services), len(allServices))
 }
 
@@ -430,18 +429,18 @@ func TestServiceGetAllMemoryReference(t *testing.T) {
 		},
 	}
 	for _, s := range services {
-		assert.Nil(collection.Add(s))
+		require.NoError(t, collection.Add(s))
 	}
 
 	allServices, err := collection.GetAll()
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(len(services), len(allServices))
 
 	allServices[0].Host = kong.String("new.example.com")
 	allServices[1].Host = kong.String("new.example.com")
 
 	service, err := collection.Get("my-service1")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(service)
 	assert.Equal("example.com", *service.Host)
 }

--- a/pkg/state/service_version_test.go
+++ b/pkg/state/service_version_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kong/go-database-reconciler/pkg/konnect"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func serviceVersionCollection() *ServiceVersionsCollection {
@@ -306,17 +307,17 @@ func TestServiceVersionDelete(t *testing.T) {
 		ID: kong.String("package-id1"),
 	}
 	err := collection.Add(serviceVersion)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get("package-id1", "my-serviceVersion")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 
 	err = collection.Delete("package-id1", *re.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("package-id1", *re.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestServiceVersionGetAll(t *testing.T) {
@@ -330,7 +331,7 @@ func TestServiceVersionGetAll(t *testing.T) {
 		ID: kong.String("id1"),
 	}
 	err := collection.Add(serviceVersion)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	var sv2 ServiceVersion
 	sv2.Version = kong.String("my-sv2")
@@ -339,12 +340,12 @@ func TestServiceVersionGetAll(t *testing.T) {
 		ID: kong.String("id1"),
 	}
 	err = collection.Add(sv2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	serviceVersions, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(serviceVersions))
+	require.NoError(t, err)
+	assert.Len(serviceVersions, 2)
 }
 
 func TestServiceVersionGetAllByServiceID(t *testing.T) {
@@ -401,14 +402,14 @@ func TestServiceVersionGetAllByServiceID(t *testing.T) {
 
 	for _, serviceVersion := range serviceVersions {
 		err := collection.Add(*serviceVersion)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 
 	serviceVersions, err := collection.GetAllByServicePackageID("id1")
-	assert.Nil(err)
-	assert.Equal(2, len(serviceVersions))
+	require.NoError(t, err)
+	assert.Len(serviceVersions, 2)
 
 	serviceVersions, err = collection.GetAllByServicePackageID("id2")
-	assert.Nil(err)
-	assert.Equal(3, len(serviceVersions))
+	require.NoError(t, err)
+	assert.Len(serviceVersions, 3)
 }

--- a/pkg/state/sni_test.go
+++ b/pkg/state/sni_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func snisCollection() *SNIsCollection {
@@ -350,15 +351,15 @@ func TestSNIGetMemoryReference(t *testing.T) {
 		ID: kong.String("cert1-id"),
 	}
 	err := collection.Add(sni)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.Equal("my-sni", *re.Name)
 
 	re, err = collection.Get("my-sni")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 }
 
@@ -373,18 +374,18 @@ func TestSNIDelete(t *testing.T) {
 		ID: kong.String("cert1-id"),
 	}
 	err := collection.Add(sni)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	re, err := collection.Get("my-sni")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(re)
 	assert.Equal("first", *re.ID)
 
 	err = collection.Delete(*re.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete(*re.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestSNIGetAll(t *testing.T) {
@@ -398,7 +399,7 @@ func TestSNIGetAll(t *testing.T) {
 		ID: kong.String("cert1-id"),
 	}
 	err := collection.Add(sni)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	var sni2 SNI
 	sni2.Name = kong.String("my-sni2")
@@ -407,12 +408,12 @@ func TestSNIGetAll(t *testing.T) {
 		ID: kong.String("cert1-id"),
 	}
 	err = collection.Add(sni2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	snis, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(snis))
+	require.NoError(t, err)
+	assert.Len(snis, 2)
 }
 
 func TestSNIGetAllByServiceID(t *testing.T) {
@@ -467,14 +468,14 @@ func TestSNIGetAllByServiceID(t *testing.T) {
 
 	for _, sni := range snis {
 		err := collection.Add(*sni)
-		assert.Nil(err)
+		require.NoError(t, err)
 	}
 
 	snis, err := collection.GetAllByCertID("cert1-id")
-	assert.Nil(err)
-	assert.Equal(2, len(snis))
+	require.NoError(t, err)
+	assert.Len(snis, 2)
 
 	snis, err = collection.GetAllByCertID("cert2-id")
-	assert.Nil(err)
-	assert.Equal(3, len(snis))
+	require.NoError(t, err)
+	assert.Len(snis, 3)
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewState(t *testing.T) {
 	state, err := NewKongState()
 	assert := assert.New(t)
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(state)
 }
 

--- a/pkg/state/upstream_test.go
+++ b/pkg/state/upstream_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func upstreamsCollection() *UpstreamsCollection {
@@ -12,31 +13,30 @@ func upstreamsCollection() *UpstreamsCollection {
 }
 
 func TestUpstreamInsert(t *testing.T) {
-	assert := assert.New(t)
 	collection := upstreamsCollection()
 
 	// name is required
 	var upstream Upstream
 	upstream.ID = kong.String("first")
 	err := collection.Add(upstream)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	// happy path
 	upstream.Name = kong.String("my-upstream")
-	assert.Nil(collection.Add(upstream))
+	require.NoError(t, collection.Add(upstream))
 
 	// ID is required
 	var upstream2 Upstream
 	upstream2.Name = kong.String("my-upstream")
 	err = collection.Add(upstream2)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	// re-insert
 	upstream2.ID = kong.String("first")
-	assert.NotNil(collection.Add(upstream2))
+	require.Error(t, collection.Add(upstream2))
 
 	upstream2.ID = kong.String("same-name-but-different-id")
-	assert.NotNil(collection.Add(upstream2))
+	require.Error(t, collection.Add(upstream2))
 }
 
 func TestUpstreamGetUpdate(t *testing.T) {
@@ -44,34 +44,34 @@ func TestUpstreamGetUpdate(t *testing.T) {
 	collection := upstreamsCollection()
 
 	se, err := collection.Get("does-not-exist")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(se)
 
 	se, err = collection.Get("")
-	assert.NotNil(err)
+	require.Error(t, err)
 	assert.Nil(se)
 
 	var upstream Upstream
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
 	err = collection.Add(upstream)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err = collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 
 	se.Name = kong.String("my-updated-upstream")
 	err = collection.Update(*se)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err = collection.Get("my-updated-upstream")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 
 	se.ID = nil
 	err = collection.Update(*se)
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	se, err = collection.Get("my-upstream")
 	assert.Equal(ErrNotFound, err)
@@ -89,15 +89,15 @@ func TestUpstreamGetMemoryReference(t *testing.T) {
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
 	err := collection.Add(upstream)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err := collection.Get("first")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	se.Slots = kong.Int(1)
 
 	se, err = collection.Get("my-upstream")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 	assert.Nil(se.Slots)
 }
@@ -130,23 +130,23 @@ func TestUpstreamDelete(t *testing.T) {
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
 	err := collection.Add(upstream)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	se, err := collection.Get("my-upstream")
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.NotNil(se)
 
 	err = collection.Delete(*se.ID)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	err = collection.Delete("")
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	_, err = collection.Get("my-upstream")
 	assert.Equal(ErrNotFound, err)
 
 	err = collection.Delete(*se.ID)
-	assert.NotNil(err)
+	require.Error(t, err)
 }
 
 func TestUpstreamGetAll(t *testing.T) {
@@ -157,16 +157,16 @@ func TestUpstreamGetAll(t *testing.T) {
 	upstream.Name = kong.String("my-upstream1")
 	upstream.ID = kong.String("first")
 	err := collection.Add(upstream)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	var upstream2 Upstream
 	upstream2.Name = kong.String("my-upstream2")
 	upstream2.ID = kong.String("second")
 	err = collection.Add(upstream2)
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	upstreams, err := collection.GetAll()
 
-	assert.Nil(err)
-	assert.Equal(2, len(upstreams))
+	require.NoError(t, err)
+	assert.Len(upstreams, 2)
 }

--- a/pkg/utils/defaulter_test.go
+++ b/pkg/utils/defaulter_test.go
@@ -34,8 +34,8 @@ func TestDefaulter(t *testing.T) {
 
 	var d Defaulter
 
-	assert.NotNil(d.Register(nil))
-	assert.NotNil(d.Set(nil))
+	require.Error(t, d.Register(nil))
+	require.Error(t, d.Set(nil))
 
 	assert.Panics(func() {
 		d.MustSet(d)
@@ -49,11 +49,11 @@ func TestDefaulter(t *testing.T) {
 		A: "defaultA",
 		B: []string{"default1"},
 	}
-	assert.Nil(d.Register(defaultFoo))
+	require.NoError(t, d.Register(defaultFoo))
 
 	// sets a default
 	var arg Foo
-	assert.Nil(d.Set(&arg))
+	require.NoError(t, d.Set(&arg))
 	assert.Equal("defaultA", arg.A)
 	assert.Equal([]string{"default1"}, arg.B)
 
@@ -61,14 +61,14 @@ func TestDefaulter(t *testing.T) {
 	arg1 := Foo{
 		A: "non-default-value",
 	}
-	assert.Nil(d.Set(&arg1))
+	require.NoError(t, d.Set(&arg1))
 	assert.Equal("non-default-value", arg1.A)
 
 	// errors on an unregistered type
 	type Bar struct {
 		A string
 	}
-	assert.NotNil(d.Set(&Bar{}))
+	require.Error(t, d.Set(&Bar{}))
 	assert.Panics(func() {
 		d.MustSet(&Bar{})
 	})
@@ -78,7 +78,7 @@ func TestServiceSetTest(t *testing.T) {
 	ctx := context.Background()
 	d, err := GetDefaulter(ctx, defaulterTestOpts)
 	require.NotNil(t, d)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	testCases := []struct {
 		desc string
@@ -149,7 +149,7 @@ func TestServiceSetTest(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			err := d.Set(tC.arg)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tC.want, tC.arg)
 		})
 	}
@@ -159,7 +159,7 @@ func TestRouteSetTest(t *testing.T) {
 	ctx := context.Background()
 	d, err := GetDefaulter(ctx, defaulterTestOpts)
 	require.NotNil(t, d)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	testCases := []struct {
 		desc string
@@ -241,7 +241,7 @@ func TestRouteSetTest(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			err := d.Set(tC.arg)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tC.want, tC.arg)
 		})
 	}
@@ -251,7 +251,7 @@ func TestUpstreamSetTest(t *testing.T) {
 	ctx := context.Background()
 	d, err := GetDefaulter(ctx, defaulterTestOpts)
 	require.NotNil(t, d)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	testCases := []struct {
 		desc string
@@ -493,7 +493,7 @@ func TestUpstreamSetTest(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			err := d.Set(tC.arg)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tC.want, tC.arg)
 		})
 	}
@@ -555,7 +555,7 @@ func TestGetDefaulter_Konnect(t *testing.T) {
 			ctx := context.Background()
 			d, err := GetDefaulter(ctx, tc.opts)
 			assert.NotNil(d)
-			assert.Nil(err)
+			require.NoError(t, err)
 
 			if !reflect.DeepEqual(d.service, tc.want.service) {
 				assert.Equal(t, tc.want.service, d.service)
@@ -621,7 +621,7 @@ func TestCheckRestrictedFields(t *testing.T) {
 				t.Errorf("got error = %v, expected error = %v", err, tC.wantErr)
 			}
 			if tC.expectedErr != "" {
-				assert.Equal(err.Error(), tC.expectedErr)
+				assert.Equal(tC.expectedErr, err.Error())
 			}
 		})
 	}

--- a/pkg/utils/tags_test.go
+++ b/pkg/utils/tags_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeTags(t *testing.T) {
@@ -21,7 +22,7 @@ func TestMergeTags(t *testing.T) {
 
 	var f Foo
 	err := MergeTags(f, []string{"tag1"})
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	assert.Panics(func() {
 		MustMergeTags(f, []string{"tag1"})
@@ -29,18 +30,18 @@ func TestMergeTags(t *testing.T) {
 
 	var bar Bar
 	err = MergeTags(&bar, []string{"tag1"})
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	f = Foo{Tags: []*string{&a, &b}}
-	assert.Nil(MergeTags(&f, []string{"tag1", "tag2", "tag3"}))
+	require.NoError(t, MergeTags(&f, []string{"tag1", "tag2", "tag3"}))
 	assert.True(equalArray([]*string{&a, &b, &c}, f.Tags))
 
 	f = Foo{Tags: []*string{}}
-	assert.Nil(MergeTags(&f, []string{"tag1", "tag2", "tag3"}))
+	require.NoError(t, MergeTags(&f, []string{"tag1", "tag2", "tag3"}))
 	assert.True(equalArray([]*string{&a, &b, &c}, f.Tags))
 
 	f = Foo{Tags: []*string{&a, &b}}
-	assert.Nil(MergeTags(&f, nil))
+	require.NoError(t, MergeTags(&f, nil))
 	assert.True(equalArray([]*string{&a, &b}, f.Tags))
 }
 
@@ -69,7 +70,7 @@ func TestRemoveTags(t *testing.T) {
 
 	var f Foo
 	err := RemoveTags(f, []string{"tag1"})
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	assert.Panics(func() {
 		MustRemoveTags(f, []string{"tag1"})
@@ -77,7 +78,7 @@ func TestRemoveTags(t *testing.T) {
 
 	var bar Bar
 	err = RemoveTags(&bar, []string{"tag1"})
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	f = Foo{Tags: []*string{&a, &b}}
 	RemoveTags(&f, []string{"tag2", "tag3"})

--- a/pkg/utils/types_test.go
+++ b/pkg/utils/types_test.go
@@ -16,11 +16,11 @@ func TestErrArrayString(t *testing.T) {
 
 	err.Errors = append(err.Errors, fmt.Errorf("foo failed"))
 
-	assert.Equal(err.Error(), "1 errors occurred:\n\tfoo failed\n")
+	assert.Equal("1 errors occurred:\n\tfoo failed\n", err.Error())
 
 	err.Errors = append(err.Errors, fmt.Errorf("bar failed"))
 
-	assert.Equal(err.Error(), "2 errors occurred:\n\tfoo failed\n\tbar failed\n")
+	assert.Equal("2 errors occurred:\n\tfoo failed\n\tbar failed\n", err.Error())
 }
 
 func Test_cleanAddress(t *testing.T) {

--- a/pkg/utils/uuid_test.go
+++ b/pkg/utils/uuid_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +10,6 @@ func TestUUID(t *testing.T) {
 	assert := assert.New(t)
 	uuid := UUID()
 	assert.NotEmpty(uuid)
-	assert.Regexp(regexp.MustCompile(
-		"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"),
+	assert.Regexp("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
 		uuid)
 }

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -6,9 +6,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kong/go-database-reconciler/pkg/utils"
 
 	deckDiff "github.com/kong/go-database-reconciler/pkg/diff"
 	deckDump "github.com/kong/go-database-reconciler/pkg/dump"
@@ -2362,7 +2363,7 @@ func Test_Diff_Workspace_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			_, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -2386,7 +2387,7 @@ func Test_Diff_Workspace_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			_, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -2417,10 +2418,10 @@ func Test_Diff_Masked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputMasked, out)
 		})
 	}
@@ -2434,10 +2435,10 @@ func Test_Diff_Masked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--json-output")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputMaskedJSON, out)
 		})
 	}
@@ -2469,10 +2470,10 @@ func Test_Diff_Masked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputMasked, out)
 		})
 	}
@@ -2485,10 +2486,10 @@ func Test_Diff_Masked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--json-output")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputMaskedJSON30x, out)
 		})
 	}
@@ -2501,10 +2502,10 @@ func Test_Diff_Masked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--json-output")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputMaskedJSON, out)
 		})
 	}
@@ -2536,10 +2537,10 @@ func Test_Diff_Unmasked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputUnMasked, out)
 		})
 	}
@@ -2552,10 +2553,10 @@ func Test_Diff_Unmasked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value", "--json-output")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputUnMaskedJSON, out)
 		})
 	}
@@ -2587,10 +2588,10 @@ func Test_Diff_Unmasked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputUnMasked, out)
 		})
 	}
@@ -2603,10 +2604,10 @@ func Test_Diff_Unmasked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value", "--json-output")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputUnMaskedJSON30x, out)
 		})
 	}
@@ -2619,10 +2620,10 @@ func Test_Diff_Unmasked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value", "--json-output")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputUnMaskedJSON, out)
 		})
 	}
@@ -2687,10 +2688,10 @@ func Test_Diff_PluginUpdate_38x(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedDiff, out)
 		})
 	}
@@ -2755,10 +2756,10 @@ func Test_Diff_PluginUpdate_NewerThan39x(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedDiff, out)
 		})
 	}
@@ -2808,10 +2809,10 @@ func Test_Diff_PluginUpdate_OlderThan38x(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedDiff, out)
 		})
 	}
@@ -2853,7 +2854,7 @@ func Test_Diff_NoDeletes_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			client, err := getTestClient()
 			ctx := context.Background()
@@ -2917,7 +2918,7 @@ func Test_Diff_NoDeletes_3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(tc.initialStateFile))
+			require.NoError(t, sync(tc.initialStateFile))
 
 			client, err := getTestClient()
 			ctx := context.Background()

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	deckDump "github.com/kong/go-database-reconciler/pkg/dump"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/go-kong/kong/custom"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_Dump_SelectTags_30(t *testing.T) {
@@ -30,17 +31,17 @@ func Test_Dump_SelectTags_30(t *testing.T) {
 			runWhen(t, "kong", ">=3.0.0 <3.1.0")
 			setup(t)
 
-			assert.NoError(t, sync(tc.stateFile))
+			require.NoError(t, sync(tc.stateFile))
 
 			output, err := dump(
 				"--select-tag", "managed-by-deck",
 				"--select-tag", "org-unit-42",
 				"-o", "-",
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, output, expected)
 		})
 	}
@@ -63,17 +64,17 @@ func Test_Dump_SelectTags_3x(t *testing.T) {
 			runWhen(t, "kong", ">=3.1.0 <3.8.0")
 			setup(t)
 
-			assert.NoError(t, sync(tc.stateFile))
+			require.NoError(t, sync(tc.stateFile))
 
 			output, err := dump(
 				"--select-tag", "managed-by-deck",
 				"--select-tag", "org-unit-42",
 				"-o", "-",
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, output, expected)
 		})
 	}
@@ -96,17 +97,17 @@ func Test_Dump_SelectTags_38x(t *testing.T) {
 			runWhen(t, "kong", ">=3.8.0")
 			setup(t)
 
-			assert.NoError(t, sync(tc.stateFile))
+			require.NoError(t, sync(tc.stateFile))
 
 			output, err := dump(
 				"--select-tag", "managed-by-deck",
 				"--select-tag", "org-unit-42",
 				"-o", "-",
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, output, expected)
 		})
 	}
@@ -182,7 +183,7 @@ func Test_Dump_SkipConsumers(t *testing.T) {
 			tc.runWhen(t)
 			setup(t)
 
-			assert.NoError(t, sync(tc.stateFile))
+			require.NoError(t, sync(tc.stateFile))
 
 			var (
 				output string
@@ -198,10 +199,10 @@ func Test_Dump_SkipConsumers(t *testing.T) {
 					"-o", "-",
 				)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}
@@ -232,7 +233,7 @@ func Test_Dump_SkipConsumers_Konnect(t *testing.T) {
 			runWhenKonnect(t)
 			setup(t)
 
-			assert.NoError(t, sync(tc.stateFile))
+			require.NoError(t, sync(tc.stateFile))
 
 			var (
 				output string
@@ -248,10 +249,10 @@ func Test_Dump_SkipConsumers_Konnect(t *testing.T) {
 					"-o", "-",
 				)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}
@@ -285,7 +286,7 @@ func Test_Dump_KonnectRename(t *testing.T) {
 			runWhenKonnect(t)
 			setup(t)
 
-			assert.NoError(t, sync(tc.stateFile))
+			require.NoError(t, sync(tc.stateFile))
 
 			var (
 				output string
@@ -295,10 +296,10 @@ func Test_Dump_KonnectRename(t *testing.T) {
 			flags = append(flags, tc.flags...)
 			output, err = dump(flags...)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}
@@ -313,10 +314,10 @@ func Test_Dump_ConsumerGroupConsumersWithCustomID(t *testing.T) {
 	var output string
 	flags := []string{"-o", "-", "--with-id"}
 	output, err := dump(flags...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected, err := readFile("testdata/sync/028-consumer-group-consumers-custom_id/kong.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, output)
 }
 
@@ -329,10 +330,10 @@ func Test_Dump_ConsumerGroupConsumersWithCustomID_Konnect(t *testing.T) {
 	var output string
 	flags := []string{"-o", "-", "--with-id"}
 	output, err := dump(flags...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected, err := readFile("testdata/dump/003-consumer-group-consumers-custom_id/konnect.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, output)
 }
 

--- a/tests/integration/lint_test.go
+++ b/tests/integration/lint_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/kong/deck/cmd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
+
+	"github.com/kong/deck/cmd"
 )
 
 func Test_LintPlain(t *testing.T) {
@@ -32,7 +34,7 @@ func Test_LintPlain(t *testing.T) {
 				"-s", tc.stateFile,
 				tc.rulesetFile,
 			)
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			assert.Contains(t, output, "Linting Violations: 2")
 			assert.Contains(t, output, "Failures: 1")
@@ -105,27 +107,27 @@ func Test_LintStructured(t *testing.T) {
 				lintOpts = append(lintOpts, "--fail-severity", tc.failSeverity)
 			}
 			output, err := lint(lintOpts...)
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			var expectedErrors, outputErrors lintErrors
 			// get expected errors from file
 			content, err := os.ReadFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if tc.format == "yaml" {
 				err = yaml.Unmarshal(content, &expectedErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// parse result errors from lint command
 				err = yaml.Unmarshal([]byte(output), &outputErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				err = json.Unmarshal(content, &expectedErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// parse result errors from lint command
 				err = json.Unmarshal([]byte(output), &outputErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			cmpOpts := []cmp.Option{

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -21,14 +21,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	deckDiff "github.com/kong/go-database-reconciler/pkg/diff"
 	deckDump "github.com/kong/go-database-reconciler/pkg/dump"
 	"github.com/kong/go-database-reconciler/pkg/state"
 	"github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -3603,7 +3604,7 @@ func Test_Sync_Vault(t *testing.T) {
 			}
 
 			res, err := client.Get("https://localhost:8443/r1")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, res.StatusCode, http.StatusOK)
 		})
 	}
@@ -3961,12 +3962,12 @@ func Test_Sync_ConsumerGroupsRLAFrom31(t *testing.T) {
 
 			// test 'foo' consumer (part of 'gold' group)
 			req, err := http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-special")
 			n := 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -3977,12 +3978,12 @@ func Test_Sync_ConsumerGroupsRLAFrom31(t *testing.T) {
 
 			// test 'bar' consumer (part of 'silver' group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-not-so-special")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -3993,12 +3994,12 @@ func Test_Sync_ConsumerGroupsRLAFrom31(t *testing.T) {
 
 			// test 'baz' consumer (not part of any group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-just-average")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -4983,12 +4984,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins(t *testing.T) {
 
 			// test 'foo' consumer (part of 'gold' group)
 			req, err := http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-special")
 			n := 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -4999,12 +5000,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins(t *testing.T) {
 
 			// test 'bar' consumer (part of 'silver' group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-not-so-special")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5015,12 +5016,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins(t *testing.T) {
 
 			// test 'baz' consumer (not part of any group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-just-average")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5276,12 +5277,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins_After350(t *testing.T) {
 
 			// test 'foo' consumer (part of 'gold' group)
 			req, err := http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-special")
 			n := 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5292,12 +5293,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins_After350(t *testing.T) {
 
 			// test 'bar' consumer (part of 'silver' group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-not-so-special")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5308,12 +5309,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins_After350(t *testing.T) {
 
 			// test 'baz' consumer (not part of any group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-just-average")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5350,7 +5351,7 @@ func Test_Sync_ConsumerGroupsScopedPlugins_Post340(t *testing.T) {
 
 			err := sync(tc.kongFile)
 			if tc.expectedError == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tc.expectedError.Error())
 			}
@@ -5831,11 +5832,11 @@ func Test_Sync_PluginScopedToConsumerGroupAndRoute(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	file, err := os.CreateTemp(cwd, "dump.*.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// dump the state.
 	_, err = dump("-o", file.Name(), "--yes")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify that the dumped state can be sync'd back and that
 	// the end result is the same.
@@ -5978,11 +5979,11 @@ func Test_Sync_PluginScopedToConsumerGroupAndRoute38x(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	file, err := os.CreateTemp(cwd, "dump.*.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// dump the state.
 	_, err = dump("-o", file.Name(), "--yes")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify that the dumped state can be sync'd back and that
 	// the end result is the same.
@@ -6128,11 +6129,11 @@ func Test_Sync_PluginScopedToConsumerGroupAndRoute39x(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	file, err := os.CreateTemp(cwd, "dump.*.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// dump the state.
 	_, err = dump("-o", file.Name(), "--yes")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify that the dumped state can be sync'd back and that
 	// the end result is the same.
@@ -6777,7 +6778,6 @@ func TestSync_License(t *testing.T) {
 }
 
 func Test_Sync_PluginDoNotFillDefaults(t *testing.T) {
-
 	client, err := getTestClient()
 
 	require.NoError(t, err)
@@ -7103,8 +7103,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	// Setup RateLimitingAdvanced ==============================
 	rateLimitingAdvancedConfigurationInitial := DefaultConfigFactory.RateLimitingAdvancedConfiguration()
 	rateLimitingAdvancedConfigurationInitial["sync_rate"] = float64(10)
-	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
+	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6380)},
@@ -7114,8 +7113,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["connect_timeout"] = float64(2000)
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["read_timeout"] = float64(2000)
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["send_timeout"] = float64(2000)
-	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["sentinel_addresses"] =
-		[]any{string("127.0.2.0:6379"), string("127.0.2.0:6380"), string("127.0.2.0:6381")}
+	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["sentinel_addresses"] = []any{string("127.0.2.0:6379"), string("127.0.2.0:6380"), string("127.0.2.0:6381")}
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["sentinel_nodes"] = []any{
 		map[string]any{"host": string("127.0.2.0"), "port": float64(6379)},
 		map[string]any{"host": string("127.0.2.0"), "port": float64(6380)},
@@ -7146,8 +7144,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	}
 
 	rateLimitingConfigurationUpdatedOldFields := rateLimitingAdvancedConfigurationInitial.DeepCopy()
-	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
+	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7380)},
@@ -7157,8 +7154,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["connect_timeout"] = float64(2007)
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["read_timeout"] = float64(2007)
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["send_timeout"] = float64(2007)
-	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["sentinel_addresses"] =
-		[]any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
+	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["sentinel_addresses"] = []any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["sentinel_nodes"] = []any{
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8379)},
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8380)},
@@ -7168,8 +7164,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 
 	openidConnectConfigurationUpdatedOldFields := openidConnectConfigurationInitial.DeepCopy()
 	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_max_redirections"] = float64(7)
-	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
+	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
 	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6380)},
@@ -7197,8 +7192,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	}
 
 	rateLimitingConfigurationUpdatedNewFields := rateLimitingAdvancedConfigurationInitial.DeepCopy()
-	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
+	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7380)},
@@ -7208,8 +7202,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["connect_timeout"] = float64(2005)
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["read_timeout"] = float64(2006)
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["send_timeout"] = float64(2007)
-	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["sentinel_addresses"] =
-		[]any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
+	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["sentinel_addresses"] = []any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["sentinel_nodes"] = []any{
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8379)},
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8380)},
@@ -7220,8 +7213,7 @@ func Test_Sync_PluginDeprecatedFields38x(t *testing.T) {
 	openidConnectConfigurationUpdatedNewFields := openidConnectConfigurationInitial.DeepCopy()
 	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_max_redirections"] = float64(11)
 	openidConnectConfigurationUpdatedNewFields["session_redis_cluster_max_redirections"] = float64(11)
-	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
+	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
 	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7380)},
@@ -7309,8 +7301,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	// Setup RateLimitingAdvanced ==============================
 	rateLimitingAdvancedConfigurationInitial := DefaultConfigFactory39x.RateLimitingAdvancedConfiguration()
 	rateLimitingAdvancedConfigurationInitial["sync_rate"] = float64(10)
-	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
+	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6380)},
@@ -7320,8 +7311,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["connect_timeout"] = float64(2000)
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["read_timeout"] = float64(2000)
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["send_timeout"] = float64(2000)
-	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["sentinel_addresses"] =
-		[]any{string("127.0.2.0:6379"), string("127.0.2.0:6380"), string("127.0.2.0:6381")}
+	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["sentinel_addresses"] = []any{string("127.0.2.0:6379"), string("127.0.2.0:6380"), string("127.0.2.0:6381")}
 	rateLimitingAdvancedConfigurationInitial["redis"].(map[string]interface{})["sentinel_nodes"] = []any{
 		map[string]any{"host": string("127.0.2.0"), "port": float64(6379)},
 		map[string]any{"host": string("127.0.2.0"), "port": float64(6380)},
@@ -7352,8 +7342,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	}
 
 	rateLimitingConfigurationUpdatedOldFields := rateLimitingAdvancedConfigurationInitial.DeepCopy()
-	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
+	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7380)},
@@ -7363,8 +7352,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["connect_timeout"] = float64(2007)
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["read_timeout"] = float64(2007)
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["send_timeout"] = float64(2007)
-	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["sentinel_addresses"] =
-		[]any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
+	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["sentinel_addresses"] = []any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
 	rateLimitingConfigurationUpdatedOldFields["redis"].(map[string]interface{})["sentinel_nodes"] = []any{
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8379)},
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8380)},
@@ -7374,8 +7362,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 
 	openidConnectConfigurationUpdatedOldFields := openidConnectConfigurationInitial.DeepCopy()
 	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_max_redirections"] = float64(7)
-	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
+	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:6379"), string("127.0.1.0:6380"), string("127.0.1.0:6381")}
 	openidConnectConfigurationUpdatedOldFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(6380)},
@@ -7403,8 +7390,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	}
 
 	rateLimitingConfigurationUpdatedNewFields := rateLimitingAdvancedConfigurationInitial.DeepCopy()
-	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
+	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7380)},
@@ -7414,8 +7400,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["connect_timeout"] = float64(2005)
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["read_timeout"] = float64(2006)
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["send_timeout"] = float64(2007)
-	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["sentinel_addresses"] =
-		[]any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
+	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["sentinel_addresses"] = []any{string("127.0.2.0:8379"), string("127.0.2.0:8380"), string("127.0.2.0:8381")}
 	rateLimitingConfigurationUpdatedNewFields["redis"].(map[string]interface{})["sentinel_nodes"] = []any{
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8379)},
 		map[string]any{"host": string("127.0.2.0"), "port": float64(8380)},
@@ -7426,8 +7411,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	openidConnectConfigurationUpdatedNewFields := openidConnectConfigurationInitial.DeepCopy()
 	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_max_redirections"] = float64(11)
 	openidConnectConfigurationUpdatedNewFields["session_redis_cluster_max_redirections"] = float64(11)
-	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] =
-		[]any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
+	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_addresses"] = []any{string("127.0.1.0:7379"), string("127.0.1.0:7380"), string("127.0.1.0:7381")}
 	openidConnectConfigurationUpdatedNewFields["redis"].(map[string]interface{})["cluster_nodes"] = []any{
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7379)},
 		map[string]any{"ip": string("127.0.1.0"), "port": float64(7380)},

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -380,7 +380,7 @@ func getKongVersion(ctx context.Context, t *testing.T, client *kong.Client) semv
 	require.NoError(t, err, "Should get no error in getting root endpoint of Kong")
 	versionStr := kong.VersionFromInfo(root)
 	kv, err := kong.ParseSemanticVersion(versionStr)
-	require.NoErrorf(t, err, "failed to parse semantic version from version string", versionStr)
+	require.NoErrorf(t, err, "failed to parse semantic version from version string %s", versionStr)
 	return semver.Version{
 		Major: kv.Major(),
 		Minor: kv.Minor(),


### PR DESCRIPTION
### Summary

Add [testifylint](https://github.com/Antonboom/testifylint) to golangci-lint config

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
