### PR TITLE
fix: fixed partial entity updates while syncing with Konnect

### DIFF
--- a/pkg/state/builder.go
+++ b/pkg/state/builder.go
@@ -281,6 +281,7 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 	}
 
 	for _, p := range raw.Partials {
+		utils.ZeroOutTimestamps(p)
 		err := kongState.Partials.Add(Partial{Partial: *p})
 		if err != nil {
 			return fmt.Errorf("inserting partial into state: %w", err)

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -7811,4 +7811,13 @@ func Test_Sync_Partials(t *testing.T) {
 		err := sync("testdata/sync/038-partials/kong-partials-no-name.yaml")
 		require.NoError(t, err)
 	})
+
+	t.Run("partial updates work without errors", func(t *testing.T) {
+		mustResetKongState(ctx, t, client, dumpConfig)
+		err := sync("testdata/sync/038-partials/kong.yaml")
+		require.NoError(t, err)
+
+		err = sync("testdata/sync/038-partials/kong-update.yaml")
+		require.NoError(t, err)
+	})
 }

--- a/tests/integration/testdata/sync/038-partials/kong-update.yaml
+++ b/tests/integration/testdata/sync/038-partials/kong-update.yaml
@@ -1,0 +1,24 @@
+_format_version: "3.0"
+partials:
+- config:
+    read_timeout: 3001
+    send_timeout: 2004
+  name: my-ee-partial
+  type: redis-ee
+  tags:
+  - tag1
+  - tag2
+  - new-tag
+plugins:
+- config:
+    limit:
+    - 10
+    window_size:
+    - 60
+    window_type: fixed
+    namespace: test-ns
+    sync_rate: -1
+  enabled: true
+  name: rate-limiting-advanced
+  partials:
+  - name: my-ee-partial


### PR DESCRIPTION
Update operations on partials were failing
while using Konnect as a backend. This was
because update payload included `created_at`
field which is read-only for Konnect. The
same does not fail with the gateway. Thus,
we are zeroing out the timestamp field
for partial while building the state.

More: https://kongstrong.slack.com/archives/C0663589T3R/p1742810047116689?thread_ts=1742795974.288409&cid=C0663589T3R

### Issues resolved

For #166 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
