### PR TITLE
fix(ci): fix dependabot PRs by skipping the enterprise tests when DockerHub tokens is missing

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Check if secrets are available
         id: check
         run: |
-          if [ "${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}" == "" ]; then
+          if [ "${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}" == "" || ${{ secrets.DOCKERHUB_PULL_TOKEN }}" == "" || ${{ secrets.DOCKERHUB_PULL_USERNAME }}" == "" ]; then
             echo "result=false" >> $GITHUB_OUTPUT
           else
             echo "result=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary

Currently we do not have the user and token defined for dependabot's scope so just skip the enterprise tests for dependabot PRs until that's resolved. 

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
