### PR TITLE
fix: ip restriction plugin diff

### DIFF
--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -579,6 +579,10 @@ func (p1 *Plugin) EqualWithOpts(p2 *Plugin, ignoreID,
 	sort.Slice(p1Copy.Tags, func(i, j int) bool { return *(p1Copy.Tags[i]) < *(p1Copy.Tags[j]) })
 	sort.Slice(p2Copy.Tags, func(i, j int) bool { return *(p2Copy.Tags[i]) < *(p2Copy.Tags[j]) })
 
+	// sort the protocols
+	sort.Slice(p1Copy.Protocols, func(i, j int) bool { return *(p1Copy.Protocols[i]) < *(p1Copy.Protocols[j]) })
+	sort.Slice(p2Copy.Protocols, func(i, j int) bool { return *(p2Copy.Protocols[i]) < *(p2Copy.Protocols[j]) })
+
 	p1Copy.Config = sortNestedArrays(p1Copy.Config)
 	p2Copy.Config = sortNestedArrays(p2Copy.Config)
 

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -579,7 +579,6 @@ func (p1 *Plugin) EqualWithOpts(p2 *Plugin, ignoreID,
 	sort.Slice(p1Copy.Tags, func(i, j int) bool { return *(p1Copy.Tags[i]) < *(p1Copy.Tags[j]) })
 	sort.Slice(p2Copy.Tags, func(i, j int) bool { return *(p2Copy.Tags[i]) < *(p2Copy.Tags[j]) })
 
-	// sort the protocols
 	sort.Slice(p1Copy.Protocols, func(i, j int) bool { return *(p1Copy.Protocols[i]) < *(p1Copy.Protocols[j]) })
 	sort.Slice(p2Copy.Protocols, func(i, j int) bool { return *(p2Copy.Protocols[i]) < *(p2Copy.Protocols[j]) })
 

--- a/pkg/state/types_test.go
+++ b/pkg/state/types_test.go
@@ -21,6 +21,17 @@ func getTags(reversed bool) []*string {
 	return []*string{&fooString, &barString}
 }
 
+// getProtocols returns a slice of test protocols. If reversed is true, the protocols are backwards!
+// backwards protocol slices are useful for confirming that our equality checks ignore protocol order
+func getProtocols(reversed bool) []*string {
+	httpString := "http"
+	httpsString := "https"
+	if reversed {
+		return []*string{&httpsString, &httpString}
+	}
+	return []*string{&httpString, &httpsString}
+}
+
 func TestMeta(t *testing.T) {
 	assert := assert.New(t)
 
@@ -281,6 +292,11 @@ func TestPluginEqual(t *testing.T) {
 	assert.True(p1.EqualWithOpts(&p2, false, false, false))
 	p1.Tags = getTags(true)
 	p2.Tags = getTags(false)
+	assert.True(p1.EqualWithOpts(&p2, false, false, false))
+
+	// Verify that plugins are equal even if protocols are out of order
+	p1.Protocols = getProtocols(true)
+	p2.Protocols = getProtocols(false)
 	assert.True(p1.EqualWithOpts(&p2, false, false, false))
 
 	p1.ID = kong.String("fuu")

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -2818,6 +2818,41 @@ func Test_Diff_PluginUpdate_OlderThan38x(t *testing.T) {
 	}
 }
 
+func Test_Diff_Plugin_Protocol_Order_Change(t *testing.T) {
+	setup(t)
+
+	tests := []struct {
+		name             string
+		initialStateFile string
+		stateFile        string
+		expectedDiff     string
+	}{
+		{
+			name:             "syncing and then diffing same file should not show false diff",
+			initialStateFile: "testdata/diff/004-plugin-update/initial-ip-restriction.yaml",
+			stateFile:        "testdata/diff/004-plugin-update/initial-ip-restriction.yaml",
+			expectedDiff:     expectedOutputPluginUpdateNoChange,
+		},
+		{
+			name:             "changing protocol order should not show diff",
+			initialStateFile: "testdata/diff/004-plugin-update/protocol-initial-order-plugins.yaml",
+			stateFile:        "testdata/diff/004-plugin-update/protocol-reordered-plugins.yaml",
+			expectedDiff:     expectedOutputPluginUpdateNoChange,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// initialize state
+			require.NoError(t, sync(tc.initialStateFile))
+
+			out, err := diff(tc.stateFile)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDiff, out)
+		})
+	}
+}
+
 func Test_Diff_NoDeletes_OlderThan3x(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/tests/integration/testdata/diff/004-plugin-update/initial-ip-restriction.yaml
+++ b/tests/integration/testdata/diff/004-plugin-update/initial-ip-restriction.yaml
@@ -1,0 +1,11 @@
+_format_version: "3.0"
+services:
+- host: a0955.spucs.apip_self-service_api_-_external.v1.stream
+  name: a0955.spucs.apip_self-service_api_-_external.v1
+  port: 443
+  protocol: https
+  plugins:
+  - config:
+      allow:
+      - 54.93.116.152/32
+    name: ip-restriction

--- a/tests/integration/testdata/diff/004-plugin-update/protocol-initial-order-plugins.yaml
+++ b/tests/integration/testdata/diff/004-plugin-update/protocol-initial-order-plugins.yaml
@@ -1,0 +1,23 @@
+_format_version: "3.0"
+services:
+- host: a0955.spucs.apip_self-service_api_-_external.v1.stream
+  name: a0955.spucs.apip_self-service_api_-_external.v1
+  port: 443
+  protocol: https
+  plugins:
+  - config:
+      allow:
+      - 54.93.116.152/32
+    name: ip-restriction
+    protocols:
+    - grpc
+    - https
+  - name: prometheus
+    service: a0955.spucs.apip_self-service_api_-_external.v1
+    tags:
+    - o11y
+    config:
+      per_consumer: false
+    protocols:
+    - grpc
+    - https

--- a/tests/integration/testdata/diff/004-plugin-update/protocol-reordered-plugins.yaml
+++ b/tests/integration/testdata/diff/004-plugin-update/protocol-reordered-plugins.yaml
@@ -1,0 +1,23 @@
+_format_version: "3.0"
+services:
+- host: a0955.spucs.apip_self-service_api_-_external.v1.stream
+  name: a0955.spucs.apip_self-service_api_-_external.v1
+  port: 443
+  protocol: https
+  plugins:
+  - config:
+      allow:
+      - 54.93.116.152/32
+    name: ip-restriction
+    protocols:
+    - https
+    - grpc
+  - name: prometheus
+    service: a0955.spucs.apip_self-service_api_-_external.v1
+    tags:
+    - o11y
+    config:
+      per_consumer: false
+    protocols:
+    - https
+    - grpc


### PR DESCRIPTION
### Summary
The issue seems to be due to the order of `protocols` defined for the ip-restriction plugin.

When we sync for the second time, if the protocols are not declared in the file we are trying to sync, we load defaults from the `/schemas/plugins/ip-restriction` endpoint on konnect - which returns them in a [given order](https://github.com/Kong/kong-ee/blob/c31e7045db6a111c254e6609c1945e9320f6d661/kong/plugins/ip-restriction/schema.lua#L14).

However, when we fetch the current state, konnect returns the plugin with the protocols sorted.
This is leading to the differ considering them unequal.

Relevant discussion: https://kongstrong.slack.com/archives/CQK8J4VN3/p1743588627387659
 

### Full changelog

* [fix: ip restriction plugin diff](https://github.com/Kong/go-database-reconciler/pull/240/commits/c006d430e75c12537b324d162d9db29431e824ff)

### Issues resolved
https://github.com/Kong/deck/issues/1571

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Pending
- [x] Add tests if relevant
- [x] Test with other plugins
- [x] Find out why only ip-restriction plugin schema has unsorted order and others don't
- [x] Do a quick search if any other fields can have same issue
