### PR TITLE
fix: moving warnings from stdout to stderr so as to not break json ouput

### DIFF
--- a/pkg/cprint/color.go
+++ b/pkg/cprint/color.go
@@ -1,6 +1,8 @@
 package cprint
 
 import (
+	"io"
+	"os"
 	"sync"
 
 	"github.com/fatih/color"
@@ -31,6 +33,15 @@ func conditionalPrintln(fn func(...interface{}), a ...interface{}) {
 	fn(a...)
 }
 
+func conditionalPrintlnCustomWriter(fn func(io.Writer, ...interface{}), w io.Writer, a ...interface{}) {
+	if DisableOutput {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	fn(w, a...)
+}
+
 var (
 	createPrintf = color.New(color.FgGreen).PrintfFunc()
 	deletePrintf = color.New(color.FgRed).PrintfFunc()
@@ -51,10 +62,11 @@ var (
 		conditionalPrintf(updatePrintf, format, a...)
 	}
 
-	createPrintln = color.New(color.FgGreen).PrintlnFunc()
-	deletePrintln = color.New(color.FgRed).PrintlnFunc()
-	updatePrintln = color.New(color.FgYellow).PrintlnFunc()
-	bluePrintln   = color.New(color.BgBlue).PrintlnFunc()
+	createPrintln  = color.New(color.FgGreen).PrintlnFunc()
+	deletePrintln  = color.New(color.FgRed).PrintlnFunc()
+	updatePrintln  = color.New(color.FgYellow).PrintlnFunc()
+	bluePrintln    = color.New(color.BgBlue).PrintlnFunc()
+	updateFprintln = color.New(color.FgYellow).FprintlnFunc()
 
 	// CreatePrintln is fmt.Println with red as foreground color.
 	CreatePrintln = func(a ...interface{}) {
@@ -73,5 +85,11 @@ var (
 
 	BluePrintLn = func(a ...interface{}) {
 		conditionalPrintln(bluePrintln, a...)
+	}
+
+	// UpdatePrintlnStdErr is fmt.Println with yellow as foreground color.
+	// It prints to stderr, instead of stdout
+	UpdatePrintlnStdErr = func(a ...interface{}) {
+		conditionalPrintlnCustomWriter(updateFprintln, os.Stderr, a...)
 	}
 )

--- a/pkg/types/basicauth.go
+++ b/pkg/types/basicauth.go
@@ -107,7 +107,7 @@ func (d *basicAuthDiffer) warnBasicAuth() {
 			"credentials using decK doesn't work due to hashing of passwords in Kong."
 	)
 	d.once.Do(func() {
-		cprint.UpdatePrintln(basicAuthPasswordWarning)
+		cprint.UpdatePrintlnStdErr(basicAuthPasswordWarning)
 	})
 }
 

--- a/pkg/types/consumer_group_plugin.go
+++ b/pkg/types/consumer_group_plugin.go
@@ -132,7 +132,7 @@ func (d *consumerGroupPluginDiffer) warnConsumerGroupPlugin() {
 			"Check https://docs.konghq.com/gateway/latest/kong-enterprise/consumer-groups/ for more information."
 	)
 	d.once.Do(func() {
-		cprint.UpdatePrintln(consumerGroupPluginWarning)
+		cprint.UpdatePrintlnStdErr(consumerGroupPluginWarning)
 	})
 }
 


### PR DESCRIPTION
For: https://github.com/Kong/deck/issues/1588

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
