### PR TITLE
chore: bump go-kong to v0.65.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/kong/deck v1.45.1-0.20250326064911-1a3c87c5bf97
-	github.com/kong/go-kong v0.65.0
+	github.com/kong/go-kong v0.65.1
 	github.com/samber/lo v1.49.1
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/ssgelm/cookiejarparser v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/kong/deck v1.45.1-0.20250326064911-1a3c87c5bf97 h1:TVbZxU37CoSILO4X0y
 github.com/kong/deck v1.45.1-0.20250326064911-1a3c87c5bf97/go.mod h1:P49UumAuP4owGZlofysjxD07QjysIHva+38xjRwTD+Q=
 github.com/kong/go-apiops v0.1.41 h1:1KXbQqyhO2E4nEnXJNqUDmHZU/LQ1U7Zoi+MAlcM2P0=
 github.com/kong/go-apiops v0.1.41/go.mod h1:sATq9Tz+ivzHKZU+tDXkRtEZnf64xroU3lgv3yXqP4I=
-github.com/kong/go-kong v0.65.0 h1:dZT+hiMhy7CQsrc9W5nHv3cFJGBGTrwlZhC5MLuf9H8=
-github.com/kong/go-kong v0.65.0/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
+github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
+github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=
 github.com/kong/go-slugify v1.0.0/go.mod h1:dbR2h3J2QKXQ1k0aww6cN7o4cIcwlWflr6RKRdcoaiw=
 github.com/kong/kubernetes-configuration v1.1.0 h1:zCj7QlOiZgwQ2wSNlVNR0K6Z+plXTalfihtDzLXQWzs=


### PR DESCRIPTION
### Summary

This bumps go-kong version containing support for loading all pages of endpoint permissions for RBAC roles.

Go kong PR: https://github.com/Kong/go-kong/pull/533

### Issues resolved
https://github.com/Kong/deck/issues/1574

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
