### PR TITLE
fix: removing constraint for foreign keys inside scoped plugin config.

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1707,7 +1707,7 @@ func (b *stateBuilder) ingestRoute(r FRoute) error {
 
 func (b *stateBuilder) ingestPlugins(plugins []FPlugin) error {
 	for _, p := range plugins {
-		cID, rID, sID, cgID := pluginRelations(&p.Plugin)
+		cID, rID, sID, cgID := b.pluginRelations(&p.Plugin)
 		plugin, err := b.currentState.Plugins.GetByProp(*p.Name,
 			sID, rID, cID, cgID)
 		if utils.Empty(p.ID) {
@@ -1755,20 +1755,50 @@ func (b *stateBuilder) fillPluginConfig(plugin *FPlugin) error {
 	return nil
 }
 
-func pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID string) {
+func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID string) {
 	if plugin.Consumer != nil && !utils.Empty(plugin.Consumer.ID) {
-		cID = *plugin.Consumer.ID
+		consumer, err := b.currentState.Consumers.GetByIDOrUsername(*plugin.Consumer.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
+			b.err = err
+		}
+
+		if consumer != nil {
+			cID = *consumer.ID
+		}
+
 	}
 	if plugin.Route != nil && !utils.Empty(plugin.Route.ID) {
-		rID = *plugin.Route.ID
+		route, err := b.currentState.Routes.Get(*plugin.Route.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
+			b.err = err
+		}
+
+		if route != nil {
+			rID = *route.ID
+		}
 	}
 	if plugin.Service != nil && !utils.Empty(plugin.Service.ID) {
-		sID = *plugin.Service.ID
+		service, err := b.currentState.Services.Get(*plugin.Service.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
+			b.err = err
+		}
+
+		if service != nil {
+			sID = *service.ID
+		}
 	}
 	if plugin.ConsumerGroup != nil && !utils.Empty(plugin.ConsumerGroup.ID) {
-		cgID = *plugin.ConsumerGroup.ID
+		consumerGroup, err := b.currentState.ConsumerGroups.Get(*plugin.ConsumerGroup.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
+			b.err = err
+		}
+
+		if consumerGroup != nil {
+			cgID = *consumerGroup.ID
+		}
 	}
-	return
+
+	return cID, rID, sID, cgID
 }
 
 func (b *stateBuilder) ingestFilterChains(filterChains []FFilterChain) error {

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1955,21 +1955,17 @@ func defaulter(
 func checkForNestedForeignKeys(plugin kong.Plugin, primary string) error {
 	var errs []error
 
-	if primary != primaryRelationConsumer && plugin.Consumer != nil && !utils.Empty(plugin.Consumer.ID) {
-		errs = append(errs, fmt.Errorf("nesting consumer (%v) under %v-scoped plugin plugin (%v) is not allowed",
+	if primary == primaryRelationConsumer && plugin.Consumer != nil && !utils.Empty(plugin.Consumer.ID) {
+		errs = append(errs, fmt.Errorf("nesting consumer (%v) under %v-scoped plugin (%v) is not allowed",
 			*plugin.Consumer.ID, primary, *plugin.Name))
 	}
-	if primary != primaryRelationRoute && plugin.Route != nil && !utils.Empty(plugin.Route.ID) {
+	if primary == primaryRelationRoute && plugin.Route != nil && !utils.Empty(plugin.Route.ID) {
 		errs = append(errs, fmt.Errorf("nesting route (%v) under %v-scoped plugin (%v) is not allowed",
 			*plugin.Route.ID, primary, *plugin.Name))
 	}
-	if primary != primaryRelationService && plugin.Service != nil && !utils.Empty(plugin.Service.ID) {
+	if primary == primaryRelationService && plugin.Service != nil && !utils.Empty(plugin.Service.ID) {
 		errs = append(errs, fmt.Errorf("nesting service (%v) under %v-scoped plugin (%v) is not allowed",
 			*plugin.Service.ID, primary, *plugin.Name))
-	}
-	if primary != primaryRelationConsumerGroup && plugin.ConsumerGroup != nil && !utils.Empty(plugin.ConsumerGroup.ID) {
-		errs = append(errs, fmt.Errorf("nesting consumer-group (%v) under %v-scoped plugin (%v) is not allowed",
-			*plugin.ConsumerGroup.ID, primary, *plugin.Name))
 	}
 	return errors.Join(errs...)
 }

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -7493,7 +7493,7 @@ func Test_Sync_PluginDeprecatedFields39x(t *testing.T) {
 	}
 }
 
-func Test_Sync_Scoped_Plugins(t *testing.T) {
+func Test_Sync_Scoped_Plugins_Same_Foreign_Key(t *testing.T) {
 	runWhen(t, "kong", "<3.0.0")
 	setup(t)
 
@@ -7503,19 +7503,19 @@ func Test_Sync_Scoped_Plugins(t *testing.T) {
 		errorExpected string
 	}{
 		{
-			name:          "syncing route-scoped plugin with service field set",
+			name:          "syncing route-scoped plugin with route field set",
 			file:          "testdata/sync/036-scoped-plugins-validation/route-plugins.yaml",
-			errorExpected: "building state: nesting service (example-service) under route-scoped plugin (request-transformer) is not allowed",
+			errorExpected: "building state: nesting route (example-route) under route-scoped plugin (request-transformer) is not allowed",
 		},
 		{
-			name:          "syncing service-scoped plugin with route and consumer field set",
+			name:          "syncing service-scoped plugin with service field set",
 			file:          "testdata/sync/036-scoped-plugins-validation/service-plugins.yaml",
-			errorExpected: "building state: nesting consumer (foo) under service-scoped plugin plugin (request-transformer) is not allowed\nnesting route (example-route) under service-scoped plugin (request-transformer) is not allowed",
+			errorExpected: "building state: nesting service (example-service) under service-scoped plugin (request-transformer) is not allowed",
 		},
 		{
-			name:          "syncing consumer-scoped plugin with service and route field set",
+			name:          "syncing consumer-scoped plugin with consumer field set",
 			file:          "testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml",
-			errorExpected: "building state: nesting route (example-route) under consumer-scoped plugin (request-transformer) is not allowed\nnesting service (example-service) under consumer-scoped plugin (request-transformer) is not allowed",
+			errorExpected: "building state: nesting consumer (foo) under consumer-scoped plugin (request-transformer) is not allowed",
 		},
 	}
 
@@ -7527,7 +7527,7 @@ func Test_Sync_Scoped_Plugins(t *testing.T) {
 	}
 }
 
-func Test_Sync_Scoped_Plugins_3x(t *testing.T) {
+func Test_Sync_Scoped_Plugins_Same_Foreign_Key_3x(t *testing.T) {
 	runWhen(t, "kong", ">=3.0.0")
 	setup(t)
 
@@ -7537,19 +7537,19 @@ func Test_Sync_Scoped_Plugins_3x(t *testing.T) {
 		errorExpected string
 	}{
 		{
-			name:          "syncing route-scoped plugin with service field set",
+			name:          "syncing route-scoped plugin with route field set",
 			file:          "testdata/sync/036-scoped-plugins-validation/3x/route-plugins.yaml",
-			errorExpected: "building state: nesting service (example-service) under route-scoped plugin (request-transformer) is not allowed",
+			errorExpected: "building state: nesting route (example-route) under route-scoped plugin (request-transformer) is not allowed",
 		},
 		{
-			name:          "syncing service-scoped plugin with route and consumer field set",
+			name:          "syncing service-scoped plugin with service field set",
 			file:          "testdata/sync/036-scoped-plugins-validation/3x/service-plugins.yaml",
-			errorExpected: "building state: nesting consumer (foo) under service-scoped plugin plugin (request-transformer) is not allowed\nnesting route (example-route) under service-scoped plugin (request-transformer) is not allowed",
+			errorExpected: "building state: nesting service (example-service) under service-scoped plugin (request-transformer) is not allowed",
 		},
 		{
-			name:          "syncing consumer-scoped plugin with service and route field set",
+			name:          "syncing consumer-scoped plugin with consumer field set",
 			file:          "testdata/sync/036-scoped-plugins-validation/3x/consumer-plugins.yaml",
-			errorExpected: "building state: nesting route (example-route) under consumer-scoped plugin (request-transformer) is not allowed\nnesting service (example-service) under consumer-scoped plugin (request-transformer) is not allowed",
+			errorExpected: "building state: nesting consumer (foo) under consumer-scoped plugin (request-transformer) is not allowed",
 		},
 	}
 

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8099,3 +8099,152 @@ func Test_Sync_Avoid_Overwrite_On_Select_Tag_Mismatch_With_ID_Enterprise(t *test
 		})
 	}
 }
+
+// test scope:
+//
+// - >=2.8.0 <3.0.0
+func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
+	runWhen(t, "kong", ">=2.8.0 <3.0.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml",
+		},
+		{
+			name:      "plugins with route reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml",
+		},
+		{
+			name:      "plugins with route reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustResetKongState(ctx, t, client, deckDump.Config{})
+			err := sync(tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// test scope:
+//
+// - >=3.0.0
+// - konnect
+func Test_Sync_Plugins_Nested_Foreign_Keys_3x(t *testing.T) {
+	runWhenKongOrKonnect(t, ">=3.0.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml",
+		},
+		{
+			name:      "plugins with route reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml",
+		},
+		{
+			name:      "plugins with route reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustResetKongState(ctx, t, client, deckDump.Config{})
+			err := sync(tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// test scope:
+//
+// - >=3.0.0+enterprise
+// - konnect
+func Test_Sync_Plugins_Nested_Foreign_Keys_EE_3x(t *testing.T) {
+	// prior versions don't support a consumer_group foreign key with a value
+	runWhenEnterpriseOrKonnect(t, ">=3.6.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer-group reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer-group reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustResetKongState(ctx, t, client, deckDump.Config{})
+			err := sync(tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/tests/integration/testdata/diff/004-plugin-update/protocol-initial-order-plugins.yaml
+++ b/tests/integration/testdata/diff/004-plugin-update/protocol-initial-order-plugins.yaml
@@ -13,7 +13,6 @@ services:
     - grpc
     - https
   - name: prometheus
-    service: mockbin
     tags:
     - o11y
     config:

--- a/tests/integration/testdata/diff/004-plugin-update/protocol-reordered-plugins.yaml
+++ b/tests/integration/testdata/diff/004-plugin-update/protocol-reordered-plugins.yaml
@@ -13,7 +13,6 @@ services:
     - https
     - grpc
   - name: prometheus
-    service: mockbin
     tags:
     - o11y
     config:

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/consumer-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/consumer-plugins.yaml
@@ -1,19 +1,11 @@
 _format_version: "3.0"
-services:
-- name: example-service
-  port: 3200
-  protocol: http
-  routes:
-  - name: example-route
-    paths:
-    - ~/r1
+
 consumers:
 - username: foo
   plugins:
   - name: request-transformer
-    route: example-route
-    service: example-service
+    consumer: foo
     config:
         add:
           querystring:
-          - test
+          - "test: check"

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/route-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/route-plugins.yaml
@@ -1,16 +1,13 @@
 _format_version: "3.0"
-services:
-- name: example-service
-  port: 3200
-  protocol: http
-  routes:
+
+routes:
   - name: example-route
     paths:
     - ~/r1
     plugins:
     - name: request-transformer
-      service: example-service
+      route: example-route
       config:
         add:
           querystring:
-          - test
+          - "test: check"

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/service-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/3x/service-plugins.yaml
@@ -1,17 +1,13 @@
 _format_version: "3.0"
+
 services:
 - name: example-service
-  port: 3200
+  host: localhost
   protocol: http
   plugins:
     - name: request-transformer
-      route: example-route
-      consumer: foo
+      service: example-service
       config:
         add:
           querystring:
-          - test
-  routes:
-  - name: example-route
-    paths:
-    - ~/r1
+          - "test: check"

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/consumer-plugins.yaml
@@ -1,19 +1,11 @@
 _format_version: "1.0"
-services:
-- name: example-service
-  port: 3200
-  protocol: http
-  routes:
-  - name: example-route
-    paths:
-    - ~/r1
+
 consumers:
 - username: foo
   plugins:
   - name: request-transformer
-    route: example-route
-    service: example-service
+    consumer: foo
     config:
         add:
           querystring:
-          - test
+          - "test: check"

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/route-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/route-plugins.yaml
@@ -1,16 +1,13 @@
 _format_version: "1.0"
-services:
-- name: example-service
-  port: 3200
-  protocol: http
-  routes:
+
+routes:
   - name: example-route
     paths:
     - ~/r1
     plugins:
     - name: request-transformer
-      service: example-service
+      route: example-route
       config:
         add:
           querystring:
-          - test
+          - "test: check"

--- a/tests/integration/testdata/sync/036-scoped-plugins-validation/service-plugins.yaml
+++ b/tests/integration/testdata/sync/036-scoped-plugins-validation/service-plugins.yaml
@@ -1,17 +1,13 @@
 _format_version: "1.0"
+
 services:
 - name: example-service
-  port: 3200
+  host: localhost
   protocol: http
   plugins:
     - name: request-transformer
-      route: example-route
-      consumer: foo
+      service: example-service
       config:
         add:
           querystring:
-          - test
-  routes:
-  - name: example-route
-    paths:
-    - ~/r1
+          - "test: check"

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # group-1's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c29666 # group-2's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-1
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-2
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # alice's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c29666 # bob's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: alice
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: bob
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c29666 # example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  paths:
+  - /r1
+  service:
+    name: example-service
+- name: example-route-2
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  paths:
+  - /r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml
@@ -1,0 +1,36 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
@@ -1,0 +1,23 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # group-1's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c29666 # group-2's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-1
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-2
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # alice's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c29666 # bob's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: alice
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: bob
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c29666 # example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+- name: example-route-2
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  paths:
+  - ~/r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml
@@ -1,0 +1,36 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
@@ -1,0 +1,24 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
@@ -1,0 +1,23 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http


### PR DESCRIPTION
### Summary

We are retaining the constraint only if
the foreign keys are of same type.
e.g; if service.plugins[i] has a service
field, it would error out

### Issues resolved

For https://github.com/Kong/deck/issues/1593

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
