### PR TITLE
fix: named foreign key references work properly for plugins

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1685,9 +1685,9 @@ func (b *stateBuilder) ingestRoute(r FRoute) error {
 	// plugins for the route
 	var plugins []FPlugin
 	for _, p := range r.Plugins {
-		// if err := checkForNestedForeignKeys(p.Plugin, primaryRelationRoute); err != nil {
-		// 	return err
-		// }
+		if err := checkForNestedForeignKeys(p.Plugin, primaryRelationRoute); err != nil {
+			return err
+		}
 		p.Route = utils.GetRouteReference(r.Route)
 		plugins = append(plugins, *p)
 	}
@@ -1757,7 +1757,7 @@ func (b *stateBuilder) fillPluginConfig(plugin *FPlugin) error {
 
 func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID string) {
 	if plugin.Consumer != nil && !utils.Empty(plugin.Consumer.ID) {
-		consumer, err := b.currentState.Consumers.GetByIDOrUsername(*plugin.Consumer.ID)
+		consumer, err := b.intermediate.Consumers.GetByIDOrUsername(*plugin.Consumer.ID)
 		if err != nil {
 			b.err = err
 		}
@@ -1768,7 +1768,7 @@ func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID
 
 	}
 	if plugin.Route != nil && !utils.Empty(plugin.Route.ID) {
-		route, err := b.currentState.Routes.Get(*plugin.Route.ID)
+		route, err := b.intermediate.Routes.Get(*plugin.Route.ID)
 		if err != nil {
 			b.err = err
 		}
@@ -1778,7 +1778,7 @@ func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID
 		}
 	}
 	if plugin.Service != nil && !utils.Empty(plugin.Service.ID) {
-		service, err := b.currentState.Services.Get(*plugin.Service.ID)
+		service, err := b.intermediate.Services.Get(*plugin.Service.ID)
 		if err != nil {
 			b.err = err
 		}
@@ -1788,11 +1788,10 @@ func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID
 		}
 	}
 	if plugin.ConsumerGroup != nil && !utils.Empty(plugin.ConsumerGroup.ID) {
-		consumerGroup, err := b.currentState.ConsumerGroups.Get(*plugin.ConsumerGroup.ID)
+		consumerGroup, err := b.intermediate.ConsumerGroups.Get(*plugin.ConsumerGroup.ID)
 		if err != nil {
 			b.err = err
 		}
-		fmt.Println("consumerGroup", consumerGroup)
 
 		if consumerGroup != nil {
 			cgID = *consumerGroup.ID

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1757,8 +1757,8 @@ func (b *stateBuilder) fillPluginConfig(plugin *FPlugin) error {
 
 func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID string) {
 	if plugin.Consumer != nil && !utils.Empty(plugin.Consumer.ID) {
-		consumer, err := b.intermediate.Consumers.GetByIDOrUsername(*plugin.Consumer.ID)
-		if err != nil {
+		consumer, err := b.currentState.Consumers.GetByIDOrUsername(*plugin.Consumer.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
 			b.err = err
 		}
 
@@ -1768,8 +1768,8 @@ func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID
 
 	}
 	if plugin.Route != nil && !utils.Empty(plugin.Route.ID) {
-		route, err := b.intermediate.Routes.Get(*plugin.Route.ID)
-		if err != nil {
+		route, err := b.currentState.Routes.Get(*plugin.Route.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
 			b.err = err
 		}
 
@@ -1778,8 +1778,8 @@ func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID
 		}
 	}
 	if plugin.Service != nil && !utils.Empty(plugin.Service.ID) {
-		service, err := b.intermediate.Services.Get(*plugin.Service.ID)
-		if err != nil {
+		service, err := b.currentState.Services.Get(*plugin.Service.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
 			b.err = err
 		}
 
@@ -1788,8 +1788,8 @@ func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID
 		}
 	}
 	if plugin.ConsumerGroup != nil && !utils.Empty(plugin.ConsumerGroup.ID) {
-		consumerGroup, err := b.intermediate.ConsumerGroups.Get(*plugin.ConsumerGroup.ID)
-		if err != nil {
+		consumerGroup, err := b.currentState.ConsumerGroups.Get(*plugin.ConsumerGroup.ID)
+		if err != nil && !errors.Is(err, state.ErrNotFound) {
 			b.err = err
 		}
 

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -275,6 +275,22 @@ func existingCACertificateState() *state.KongState {
 
 func existingPluginState() *state.KongState {
 	s, _ := state.NewKongState()
+	s.Consumers.Add(state.Consumer{
+		Consumer: kong.Consumer{
+			ID: kong.String("f77ca8c7-581d-45a4-a42c-c003234228e1"),
+		},
+	})
+	s.Routes.Add(state.Route{
+		Route: kong.Route{
+			ID: kong.String("700bc504-b2b1-4abd-bd38-cec92779659e"),
+		},
+	})
+	s.ConsumerGroups.Add(state.ConsumerGroup{
+		ConsumerGroup: kong.ConsumerGroup{
+			ID:   kong.String("69ed4618-a653-4b54-8bb6-dc33bd6fe048"),
+			Name: kong.String("test-group"),
+		},
+	})
 	s.Plugins.Add(state.Plugin{
 		Plugin: kong.Plugin{
 			ID:   kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -308,6 +308,56 @@ func existingPluginState() *state.KongState {
 	return s
 }
 
+func existingScopedPluginState() *state.KongState {
+	s, _ := state.NewKongState()
+
+	s.Consumers.Add(state.Consumer{
+		Consumer: kong.Consumer{
+			ID: kong.String("cID"),
+		},
+	})
+
+	s.Services.Add(state.Service{
+		Service: kong.Service{
+			ID: kong.String("sID"),
+		},
+	})
+
+	s.Routes.Add(state.Route{
+		Route: kong.Route{
+			ID: kong.String("rID"),
+		},
+	})
+
+	s.ConsumerGroups.Add(state.ConsumerGroup{
+		ConsumerGroup: kong.ConsumerGroup{
+			ID:   kong.String("cgID"),
+			Name: kong.String("foo"),
+		},
+	})
+
+	s.Plugins.Add(state.Plugin{
+		Plugin: kong.Plugin{
+			ID:   kong.String("53ce0a9c-d518-40ee-b8ab-1ee83a20d382"),
+			Name: kong.String("foo"),
+			Consumer: &kong.Consumer{
+				ID: kong.String("cID"),
+			},
+			Route: &kong.Route{
+				ID: kong.String("rID"),
+			},
+			ConsumerGroup: &kong.ConsumerGroup{
+				ID: kong.String("cgID"),
+			},
+			Service: &kong.Service{
+				ID: kong.String("sID"),
+			},
+		},
+	})
+
+	return s
+}
+
 func existingTargetsState() *state.KongState {
 	s, _ := state.NewKongState()
 	s.Targets.Add(state.Target{
@@ -1079,12 +1129,13 @@ func Test_pluginRelations(t *testing.T) {
 		plugin *kong.Plugin
 	}
 	tests := []struct {
-		name     string
-		args     args
-		wantCID  string
-		wantRID  string
-		wantSID  string
-		wantCGID string
+		name         string
+		args         args
+		wantCID      string
+		wantRID      string
+		wantSID      string
+		wantCGID     string
+		currentState *state.KongState
 	}{
 		{
 			args: args{
@@ -1092,10 +1143,11 @@ func Test_pluginRelations(t *testing.T) {
 					Name: kong.String("foo"),
 				},
 			},
-			wantCID:  "",
-			wantRID:  "",
-			wantSID:  "",
-			wantCGID: "",
+			wantCID:      "",
+			wantRID:      "",
+			wantSID:      "",
+			wantCGID:     "",
+			currentState: emptyState(),
 		},
 		{
 			args: args{
@@ -1115,15 +1167,19 @@ func Test_pluginRelations(t *testing.T) {
 					},
 				},
 			},
-			wantCID:  "cID",
-			wantRID:  "rID",
-			wantSID:  "sID",
-			wantCGID: "cgID",
+			wantCID:      "cID",
+			wantRID:      "rID",
+			wantSID:      "sID",
+			wantCGID:     "cgID",
+			currentState: existingScopedPluginState(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCID, gotRID, gotSID, gotCGID := pluginRelations(tt.args.plugin)
+			b := &stateBuilder{
+				currentState: tt.currentState,
+			}
+			gotCID, gotRID, gotSID, gotCGID := b.pluginRelations(tt.args.plugin)
 			if gotCID != tt.wantCID {
 				t.Errorf("pluginRelations() gotCID = %v, want %v", gotCID, tt.wantCID)
 			}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8102,9 +8102,64 @@ func Test_Sync_Avoid_Overwrite_On_Select_Tag_Mismatch_With_ID_Enterprise(t *test
 
 // test scope:
 //
-// - >=2.8.0
-// - konnect
+// - >=2.8.0 <3.0.0
 func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
+	runWhen(t, "kong", ">=2.8.0 <3.0.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml",
+		},
+		{
+			name:      "plugins with route reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml",
+		},
+		{
+			name:      "plugins with route reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustResetKongState(ctx, t, client, deckDump.Config{})
+			err := sync(tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+
+}
+
+// test scope:
+//
+// - >=3.0.0
+// - konnect
+func Test_Sync_Plugins_Nested_Foreign_Keys_3x(t *testing.T) {
 	runWhenKongOrKonnect(t, ">=2.8.0")
 	setup(t)
 
@@ -8158,9 +8213,10 @@ func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
 
 // test scope:
 //
-// - >=2.8.0+enterprise
-func Test_Sync_Plugins_Nested_Foreign_Keys_EE(t *testing.T) {
-	runWhen(t, "enterprise", ">=2.8.0")
+// - >=3.0.0+enterprise
+// - konnect
+func Test_Sync_Plugins_Nested_Foreign_Keys_EE_3x(t *testing.T) {
+	runWhenEnterpriseOrKonnect(t, ">=3.0.0")
 	setup(t)
 
 	client, err := getTestClient()

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8099,3 +8099,97 @@ func Test_Sync_Avoid_Overwrite_On_Select_Tag_Mismatch_With_ID_Enterprise(t *test
 		})
 	}
 }
+
+// test scope:
+//
+// - >=2.8.0
+// - konnect
+func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
+	runWhenKongOrKonnect(t, ">=2.8.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml",
+		},
+		{
+			name:      "plugins with route reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml",
+		},
+		{
+			name:      "plugins with route reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustResetKongState(ctx, t, client, deckDump.Config{})
+			err := sync(tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+
+}
+
+// test scope:
+//
+// - >=2.8.0+enterprise
+func Test_Sync_Plugins_Nested_Foreign_Keys_EE(t *testing.T) {
+	runWhen(t, "enterprise", ">=2.8.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer-group reference - via name",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer-group reference - via id",
+			stateFile: "testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustResetKongState(ctx, t, client, deckDump.Config{})
+			err := sync(tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8152,7 +8152,6 @@ func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-
 }
 
 // test scope:
@@ -8208,7 +8207,6 @@ func Test_Sync_Plugins_Nested_Foreign_Keys_3x(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-
 }
 
 // test scope:

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8216,7 +8216,8 @@ func Test_Sync_Plugins_Nested_Foreign_Keys_3x(t *testing.T) {
 // - >=3.0.0+enterprise
 // - konnect
 func Test_Sync_Plugins_Nested_Foreign_Keys_EE_3x(t *testing.T) {
-	runWhenEnterpriseOrKonnect(t, ">=3.0.0")
+	// prior versions don't support a consumer_group foreign key with a value
+	runWhenEnterpriseOrKonnect(t, ">=3.6.0")
 	setup(t)
 
 	client, err := getTestClient()

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8160,7 +8160,7 @@ func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
 // - >=3.0.0
 // - konnect
 func Test_Sync_Plugins_Nested_Foreign_Keys_3x(t *testing.T) {
-	runWhenKongOrKonnect(t, ">=2.8.0")
+	runWhenKongOrKonnect(t, ">=3.0.0")
 	setup(t)
 
 	client, err := getTestClient()

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # group-1's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c29666 # group-2's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-1
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-2
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # alice's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c29666 # bob's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: alice
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: bob
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c29666 # example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  paths:
+  - /r1
+  service:
+    name: example-service
+- name: example-route-2
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  paths:
+  - /r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml
@@ -1,0 +1,36 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
@@ -22,17 +22,3 @@ routes:
       name: rate-limiting
       protocols:
         - http
-- name: example-route-2
-  paths:
-  - /r2
-  service:
-    name: example-service
-  plugins:
-    - config:
-        minute: 200
-        policy: local
-      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
-      enabled: true
-      name: rate-limiting
-      protocols:
-        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 200
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
@@ -21,17 +21,3 @@ routes:
       name: rate-limiting
       protocols:
         - http
-- name: example-route-2
-  paths:
-  - /r2
-  service:
-    name: example-service
-  plugins:
-    - config:
-        minute: 200
-        policy: local
-      service: example-service
-      enabled: true
-      name: rate-limiting
-      protocols:
-        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
@@ -1,0 +1,37 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 200
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # group-1's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c29666 # group-2's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-1
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-2
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # alice's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c29666 # bob's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: alice
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: bob
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c29666 # example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+- name: example-route-2
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  paths:
+  - ~/r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml
@@ -1,0 +1,36 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 200
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
@@ -22,17 +22,3 @@ routes:
       name: rate-limiting
       protocols:
         - http
-- name: example-route-2
-  paths:
-  - ~/r2
-  service:
-    name: example-service
-  plugins:
-    - config:
-        minute: 200
-        policy: local
-      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
-      enabled: true
-      name: rate-limiting
-      protocols:
-        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
@@ -21,17 +21,3 @@ routes:
       name: rate-limiting
       protocols:
         - http
-- name: example-route-2
-  paths:
-  - ~/r2
-  service:
-    name: example-service
-  plugins:
-    - config:
-        minute: 200
-        policy: local
-      service: example-service
-      enabled: true
-      name: rate-limiting
-      protocols:
-        - http

--- a/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
+++ b/tests/integration/testdata/sync/040-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
@@ -1,0 +1,37 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 200
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http


### PR DESCRIPTION
Till deck v1.42.1, references in plugin
config worked fine if IDs were passed.
If names were passed, the first sync
went fine, but all the next syncs
showed unique key violation error.
This was because names were getting
resolved as IDs and then processed for
fetching the plugin from currentState,
which gave a 404. Thus, a new plugin
was getting created each time, leading
to uniqueness violation error.

With deck v1.43.0, we were not
allowing nested foreign keys. We are 
relaxing this constraint here:
https://github.com/Kong/go-database-reconciler/pull/249
Thus, necessary changes are added 
to make this work properly with named references.

### Issues resolved

For https://github.com/Kong/deck/issues/1595

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
