### PR TITLE
fix: partial apply for custom entities

### DIFF
--- a/pkg/state/builder.go
+++ b/pkg/state/builder.go
@@ -405,10 +405,9 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 			if err != nil {
 				return err
 			}
-			if !ok {
-				return fmt.Errorf("service %q not found", *d.Service.ID)
+			if ok {
+				d.Service = s
 			}
-			d.Service = s
 		}
 		err := kongState.DegraphqlRoutes.Add(DegraphqlRoute{DegraphqlRoute: *d})
 		if err != nil {

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	deckDump "github.com/kong/go-database-reconciler/pkg/dump"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Apply_Custom_Entities(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.0.0")
+	setup(t)
+	client, err := getTestClient()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	ctx := context.Background()
+	tests := []struct {
+		name                   string
+		initialStateFile       string
+		targetPartialStateFile string
+	}{
+		{
+			name:                   "certificate",
+			initialStateFile:       "testdata/apply/001-custom-entities/initial-state.yaml",
+			targetPartialStateFile: "testdata/apply/001-custom-entities/partial-update.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mustResetKongState(ctx, t, client, deckDump.Config{})
+			err := sync(tc.initialStateFile)
+			require.NoError(t, err)
+
+			err = apply(tc.targetPartialStateFile)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -24,7 +24,7 @@ func Test_Apply_Custom_Entities(t *testing.T) {
 		targetPartialStateFile string
 	}{
 		{
-			name:                   "certificate",
+			name:                   "custom entity - degraphql routes",
 			initialStateFile:       "testdata/apply/001-custom-entities/initial-state.yaml",
 			targetPartialStateFile: "testdata/apply/001-custom-entities/partial-update.yaml",
 		},

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -297,6 +297,16 @@ func multiFileSync(kongFiles []string, opts ...string) error {
 	return deckCmd.ExecuteContext(context.Background())
 }
 
+func apply(kongFile string, opts ...string) error {
+	deckCmd := cmd.NewRootCmd()
+	args := []string{"gateway", "apply", kongFile}
+	if len(opts) > 0 {
+		args = append(args, opts...)
+	}
+	deckCmd.SetArgs(args)
+	return deckCmd.ExecuteContext(context.Background())
+}
+
 func diff(kongFile string, opts ...string) (string, error) {
 	deckCmd := cmd.NewRootCmd()
 	args := []string{"gateway", "diff", kongFile}

--- a/tests/integration/testdata/apply/001-custom-entities/initial-state.yaml
+++ b/tests/integration/testdata/apply/001-custom-entities/initial-state.yaml
@@ -1,0 +1,23 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  name: example
+  plugins:
+  - config:
+      graphql_server_path: /graphql
+    enabled: true
+    name: degraphql
+    protocols:
+    - grpc
+    - grpcs
+    - http
+    - https
+  port: 443
+  protocol: https
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  tags:
+    - foo' 

--- a/tests/integration/testdata/apply/001-custom-entities/partial-update.yaml
+++ b/tests/integration/testdata/apply/001-custom-entities/partial-update.yaml
@@ -1,0 +1,10 @@
+_format_version: "3.0"
+custom_entities:
+- fields:
+    methods:
+    - GET
+    query: query { viewer { login } }
+    service:
+      name: example
+    uri: /me
+  type: degraphql_routes


### PR DESCRIPTION
### Summary

In this PR, we are ignoring the error returned from `ensureService` for Degraphql routes - similar to how other entities behave so that gateway apply command is fixed for custom entities.

### Issues resolved
https://github.com/Kong/deck/issues/1568


### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
