### PR TITLE
fix: fetch partials in case of nested plugins

### DIFF
--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1559,10 +1559,6 @@ func (b *stateBuilder) plugins() {
 			p.ConsumerGroup = utils.GetConsumerGroupReference(cg.ConsumerGroup)
 		}
 
-		if p.Partials != nil {
-			p.Partials = b.findLinkedPartials(&p.Plugin)
-		}
-
 		if err := b.validatePlugin(p); err != nil {
 			b.err = err
 			return
@@ -1786,7 +1782,7 @@ func (b *stateBuilder) ingestPlugins(plugins []FPlugin) error {
 			}
 		}
 		if p.Partials != nil {
-			plugin.Partials = b.findLinkedPartials(&p.Plugin)
+			p.Partials = b.findLinkedPartials(&p.Plugin)
 		}
 		if p.Config == nil {
 			p.Config = make(map[string]interface{})

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1909,7 +1909,7 @@ func (b *stateBuilder) findLinkedPartials(plugin *kong.Plugin) []*kong.PartialLi
 		}
 
 		if utils.Empty(findID) {
-			b.err = fmt.Errorf("partial for plugin %v: partial ID or name is required", *plugin.Name)
+			b.err = fmt.Errorf("partial for plugin %v: either partial ID or name is required", *plugin.Name)
 			return nil
 		}
 

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1560,40 +1560,7 @@ func (b *stateBuilder) plugins() {
 		}
 
 		if p.Partials != nil {
-			var pluginPartials []*kong.PartialLink
-			for _, partial := range p.Partials {
-				if partial.Partial == nil {
-					continue
-				}
-
-				var findID *string
-				if !utils.Empty(partial.Partial.ID) {
-					findID = partial.Partial.ID
-				} else if !utils.Empty(partial.Partial.Name) {
-					findID = partial.Partial.Name
-				}
-
-				if utils.Empty(findID) {
-					b.err = fmt.Errorf("partial for plugin %v: partial ID or name is required", *p.Name)
-					return
-				}
-
-				pt, err := b.intermediate.Partials.Get(*findID)
-				if errors.Is(err, state.ErrNotFound) {
-					b.err = fmt.Errorf("partial %v for plugin %v: %w",
-						partial.Partial.FriendlyName(), *p.Name, err)
-					return
-				} else if err != nil {
-					b.err = err
-					return
-				}
-				pluginPartials = append(pluginPartials, &kong.PartialLink{
-					Partial: utils.GetPartialReference(pt.Partial),
-					Path:    partial.Path,
-				})
-
-			}
-			p.Partials = pluginPartials
+			p.Partials = b.findLinkedPartials(&p.Plugin)
 		}
 
 		if err := b.validatePlugin(p); err != nil {
@@ -1818,6 +1785,9 @@ func (b *stateBuilder) ingestPlugins(plugins []FPlugin) error {
 				p.ID = kong.String(*plugin.ID)
 			}
 		}
+		if p.Partials != nil {
+			plugin.Partials = b.findLinkedPartials(&p.Plugin)
+		}
 		if p.Config == nil {
 			p.Config = make(map[string]interface{})
 		}
@@ -1925,6 +1895,44 @@ func (b *stateBuilder) pluginRelations(plugin *kong.Plugin) (cID, rID, sID, cgID
 	}
 
 	return cID, rID, sID, cgID
+}
+
+func (b *stateBuilder) findLinkedPartials(plugin *kong.Plugin) []*kong.PartialLink {
+	var pluginPartials []*kong.PartialLink
+	for _, partial := range plugin.Partials {
+		if partial.Partial == nil {
+			b.err = fmt.Errorf("partial for plugin %v: missing required fields - name or id", *plugin.Name)
+			return nil
+		}
+
+		var findID *string
+		if !utils.Empty(partial.Partial.ID) {
+			findID = partial.Partial.ID
+		} else if !utils.Empty(partial.Partial.Name) {
+			findID = partial.Partial.Name
+		}
+
+		if utils.Empty(findID) {
+			b.err = fmt.Errorf("partial for plugin %v: partial ID or name is required", *plugin.Name)
+			return nil
+		}
+
+		pt, err := b.intermediate.Partials.Get(*findID)
+		if errors.Is(err, state.ErrNotFound) {
+			b.err = fmt.Errorf("partial %v for plugin %v: %w",
+				partial.Partial.FriendlyName(), *plugin.Name, err)
+			return nil
+		} else if err != nil {
+			b.err = err
+			return nil
+		}
+		pluginPartials = append(pluginPartials, &kong.PartialLink{
+			Partial: utils.GetPartialReference(pt.Partial),
+			Path:    partial.Path,
+		})
+	}
+
+	return pluginPartials
 }
 
 func (b *stateBuilder) ingestFilterChains(filterChains []FFilterChain) error {

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -5098,7 +5098,7 @@ func Test_stateBuilder_plugins(t *testing.T) {
 				},
 				intermediate: emptyState(),
 			},
-			wantErr: "partial for plugin custom-plugin: partial ID or name is required",
+			wantErr: "partial for plugin custom-plugin: either partial ID or name is required",
 		},
 		{
 			name: "error when partial is not found",

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8132,7 +8132,7 @@ func Test_Sync_Partials_Plugins(t *testing.T) {
 		mustResetKongState(ctx, t, client, dumpConfig)
 		err := sync("testdata/sync/038-partials/plugin-partial-no-ids.yaml")
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: partial ID or name is required")
+		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: either partial ID or name is required")
 
 		err = sync("testdata/sync/038-partials/ill-formatted-partial.yaml")
 		require.Error(t, err)
@@ -8195,7 +8195,7 @@ func Test_Sync_Partials_Plugins(t *testing.T) {
 		mustResetKongState(ctx, t, client, dumpConfig)
 		err := sync("testdata/sync/038-partials/nested-plugin-partial-no-ids.yaml")
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: partial ID or name is required")
+		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: either partial ID or name is required")
 
 		err = sync("testdata/sync/038-partials/nested-plugin-ill-formatted-partial.yaml")
 		require.Error(t, err)

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8127,6 +8127,80 @@ func Test_Sync_Partials_Plugins(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "partial non-existent-partial for plugin rate-limiting-advanced: entity not found")
 	})
+
+	t.Run("partial linking fails if partial information is not provided properly", func(t *testing.T) {
+		mustResetKongState(ctx, t, client, dumpConfig)
+		err := sync("testdata/sync/038-partials/plugin-partial-no-ids.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: partial ID or name is required")
+
+		err = sync("testdata/sync/038-partials/ill-formatted-partial.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: missing required fields - name or id")
+	})
+
+	t.Run("partial linking works fine in case of nested plugin", func(t *testing.T) {
+		mustResetKongState(ctx, t, client, dumpConfig)
+		currentState, err := fetchCurrentState(ctx, client, dumpConfig)
+		require.NoError(t, err)
+
+		targetState := stateFromFile(ctx, t, "testdata/sync/038-partials/nested-plugin-partials.yaml", client, dumpConfig)
+		syncer, err := deckDiff.NewSyncer(deckDiff.SyncerOpts{
+			CurrentState: currentState,
+			TargetState:  targetState,
+
+			KongClient: client,
+		})
+		require.NoError(t, err)
+
+		stats, errs, changes := syncer.Solve(ctx, 1, false, true)
+		require.Empty(t, errs, "Should have no errors in syncing")
+		logEntityChanges(t, stats, changes)
+
+		newState, err := fetchCurrentState(ctx, client, dumpConfig)
+		require.NoError(t, err)
+
+		// check for partial
+		partials, err := newState.Partials.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, partials)
+
+		require.Len(t, partials, 1)
+		assert.Equal(t, "13dc230d-d65e-439a-9f05-9fd71abfee4d", *partials[0].ID)
+		assert.Equal(t, "my-ee-partial", *partials[0].Name)
+		assert.Equal(t, "redis-ee", *partials[0].Type)
+		assert.IsType(t, kong.Configuration{}, partials[0].Config)
+		assert.Equal(t, partialConfig, partials[0].Config)
+
+		// check for plugin
+		plugins, err := newState.Plugins.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, plugins)
+		require.Len(t, plugins, 1)
+		assert.Equal(t, "rate-limiting-advanced", *plugins[0].Name)
+		assert.IsType(t, []*kong.PartialLink{}, plugins[0].Partials)
+		require.Len(t, plugins[0].Partials, 1)
+		assert.Equal(t, "13dc230d-d65e-439a-9f05-9fd71abfee4d", *plugins[0].Partials[0].ID)
+		assert.Equal(t, "config.redis", *plugins[0].Partials[0].Path)
+	})
+
+	t.Run("partial linking fails in a nested plugin if partial does not exist", func(t *testing.T) {
+		mustResetKongState(ctx, t, client, dumpConfig)
+		err := sync("testdata/sync/038-partials/nested-plugin-partial-not-exists.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "partial non-existent-partial for plugin rate-limiting-advanced: entity not found")
+	})
+
+	t.Run("partial linking fails in a nested plugin if partial information is not provided properly", func(t *testing.T) {
+		mustResetKongState(ctx, t, client, dumpConfig)
+		err := sync("testdata/sync/038-partials/nested-plugin-partial-no-ids.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: partial ID or name is required")
+
+		err = sync("testdata/sync/038-partials/nested-plugin-ill-formatted-partial.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "partial for plugin rate-limiting-advanced: missing required fields - name or id")
+	})
 }
 
 func Test_Sync_Partials(t *testing.T) {

--- a/tests/integration/testdata/sync/038-partials/ill-formatted-partial.yaml
+++ b/tests/integration/testdata/sync/038-partials/ill-formatted-partial.yaml
@@ -1,0 +1,16 @@
+_format_version: "3.0"
+
+plugins:
+  - config:
+      identifier: ip
+      limit:
+      - 10000
+      namespace: testns
+      strategy: redis
+      sync_rate: 2
+      window_size:
+      - 30
+      window_type: sliding
+    name: rate-limiting-advanced
+    partials:
+    - path: config.redis

--- a/tests/integration/testdata/sync/038-partials/nested-plugin-ill-formatted-partial.yaml
+++ b/tests/integration/testdata/sync/038-partials/nested-plugin-ill-formatted-partial.yaml
@@ -1,0 +1,26 @@
+_format_version: "3.0"
+
+services:
+- host: httpbin.konghq.com
+  name: httpbin
+  path: /anything
+  plugins:
+  - config:
+      identifier: ip
+      limit:
+      - 10000
+      namespace: testns
+      strategy: redis
+      sync_rate: 2
+      window_size:
+      - 30
+      window_type: sliding
+    name: rate-limiting-advanced
+    partials:
+    - path: config.redis
+  port: 443
+  protocol: https
+  routes:
+  - name: anything
+    paths:
+    - /anything

--- a/tests/integration/testdata/sync/038-partials/nested-plugin-partial-no-ids.yaml
+++ b/tests/integration/testdata/sync/038-partials/nested-plugin-partial-no-ids.yaml
@@ -1,0 +1,27 @@
+_format_version: "3.0"
+
+services:
+- host: httpbin.konghq.com
+  name: httpbin
+  path: /anything
+  plugins:
+  - config:
+      identifier: ip
+      limit:
+      - 10000
+      namespace: testns
+      strategy: redis
+      sync_rate: 2
+      window_size:
+      - 30
+      window_type: sliding
+    name: rate-limiting-advanced
+    partials:
+    - id: null
+      path: config.redis
+  port: 443
+  protocol: https
+  routes:
+  - name: anything
+    paths:
+    - /anything

--- a/tests/integration/testdata/sync/038-partials/nested-plugin-partial-not-exists.yaml
+++ b/tests/integration/testdata/sync/038-partials/nested-plugin-partial-not-exists.yaml
@@ -1,0 +1,28 @@
+_format_version: "3.0"
+
+services:
+- host: httpbin.konghq.com
+  name: httpbin
+  path: /anything
+  plugins:
+  - config:
+      identifier: ip
+      limit:
+      - 10000
+      namespace: testns
+      strategy: redis
+      sync_rate: 2
+      window_size:
+      - 30
+      window_type: sliding
+    name: rate-limiting-advanced
+    partials:
+    - id: 13dc230d-d65e-439a-9f05-9fd71abfee4d
+      name: non-existent-partial
+      path: config.redis
+  port: 443
+  protocol: https
+  routes:
+  - name: anything
+    paths:
+    - /anything

--- a/tests/integration/testdata/sync/038-partials/nested-plugin-partials.yaml
+++ b/tests/integration/testdata/sync/038-partials/nested-plugin-partials.yaml
@@ -1,0 +1,34 @@
+_format_version: "3.0"
+partials:
+- config:
+    read_timeout: 3001
+    send_timeout: 2004
+  name: my-ee-partial
+  type: redis-ee
+  id: 13dc230d-d65e-439a-9f05-9fd71abfee4d
+services:
+- host: httpbin.konghq.com
+  name: httpbin
+  path: /anything
+  plugins:
+  - config:
+      identifier: ip
+      limit:
+      - 10000
+      namespace: testns
+      strategy: redis
+      sync_rate: 2
+      window_size:
+      - 30
+      window_type: sliding
+    name: rate-limiting-advanced
+    partials:
+    - id: 13dc230d-d65e-439a-9f05-9fd71abfee4d
+      name: my-ee-partial
+      path: config.redis
+  port: 443
+  protocol: https
+  routes:
+  - name: anything
+    paths:
+    - /anything

--- a/tests/integration/testdata/sync/038-partials/plugin-partial-no-ids.yaml
+++ b/tests/integration/testdata/sync/038-partials/plugin-partial-no-ids.yaml
@@ -1,0 +1,27 @@
+_format_version: "3.0"
+
+services:
+- host: httpbin.konghq.com
+  name: httpbin
+  path: /anything
+  plugins:
+  - config:
+      identifier: ip
+      limit:
+      - 10000
+      namespace: testns
+      strategy: redis
+      sync_rate: 2
+      window_size:
+      - 30
+      window_type: sliding
+    name: rate-limiting-advanced
+    partials:
+    - id: null
+      path: config.redis
+  port: 443
+  protocol: https
+  routes:
+  - name: anything
+    paths:
+    - /anything


### PR DESCRIPTION
### Summary

Partial linking for nested plugins was not
working well as it was unaccounted for.
Now, `ingestPlugin()` method links the
partials to the plugins. As this method
is used by other entities that may have a
nested plugin, it would be ensured that all
entities with a nested plugin that use a
partial are able to link it to one.

### Issues resolved

For https://github.com/Kong/deck/issues/1649

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
