### PR TITLE
feat: add `control_plane_id` field to the dumped configuration

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -58,7 +58,8 @@ type Config struct {
 	LookUpSelectorTagsPartials       []string
 
 	// KonnectControlPlane
-	KonnectControlPlane string
+	KonnectControlPlane   string
+	KonnectControlPlaneID string
 
 	// IsConsumerGroupScopedPluginSupported
 	IsConsumerGroupScopedPluginSupported bool

--- a/pkg/file/kong_json_schema.json
+++ b/pkg/file/kong_json_schema.json
@@ -1660,6 +1660,9 @@
         "control_plane_name": {
           "type": "string"
         },
+        "control_plane_id": {
+          "type": "string"
+        },
         "runtime_group_name": {
           "type": "string"
         }

--- a/pkg/file/types.go
+++ b/pkg/file/types.go
@@ -802,6 +802,7 @@ type LookUpSelectorTags struct {
 type Konnect struct {
 	RuntimeGroupName string `json:"runtime_group_name,omitempty" yaml:"runtime_group_name,omitempty"`
 	ControlPlaneName string `json:"control_plane_name,omitempty" yaml:"control_plane_name,omitempty"`
+	ControlPlaneID   string `json:"control_plane_id,omitempty" yaml:"control_plane_id,omitempty"`
 }
 
 // Kong represents Kong implementation of a Service in Konnect.

--- a/pkg/file/writer.go
+++ b/pkg/file/writer.go
@@ -24,6 +24,7 @@ type WriteConfig struct {
 	FileFormat                       Format
 	WithID                           bool
 	ControlPlaneName                 string
+	ControlPlaneID                   string
 	KongVersion                      string
 	IsConsumerGroupPolicyOverrideSet bool
 }
@@ -60,6 +61,9 @@ func KongStateToContent(kongState *state.KongState, config WriteConfig) (*Conten
 		file.Konnect = &Konnect{
 			ControlPlaneName: config.ControlPlaneName,
 		}
+	}
+	if config.ControlPlaneID != "" {
+		file.Konnect.ControlPlaneID = config.ControlPlaneID
 	}
 
 	selectTags := config.SelectTags


### PR DESCRIPTION
### Summary

Add the field `control_plane_id` to the Konnect schema to support its usage via `deck`

supersedes #303 

### Full changelog

* Add the field `control_plane_id` to the Konnect schema to support its usage via `deck`

### Issues resolved

n/a

### Documentation

[dependent PR](https://github.com/Kong/deck/pull/1679)

### Testing

Once confirmed that the changes are done in the correct places, I will add more tests

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes