### PR TITLE
chore: bump go version to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/go-database-reconciler
 
-go 1.24.3
+go 1.24.4
 
 replace github.com/yudai/gojsondiff v1.0.0 => github.com/Kong/gojsondiff v1.3.0
 


### PR DESCRIPTION
### Summary

This resolves a few known vulnerabilities -[GO-2025-3751](https://pkg.go.dev/vuln/GO-2025-3751), [GO-2025-3750](https://pkg.go.dev/vuln/GO-2025-3750) and [GO-2025-3749](https://pkg.go.dev/vuln/GO-2025-3749)

### Issues resolved

https://github.com/Kong/deck/issues/1688

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
