### PR TITLE
chore: add 3.11 to test matrix

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -26,6 +26,7 @@ jobs:
         - 'kong/kong-gateway:3.8'
         - 'kong/kong-gateway:3.9'
         - 'kong/kong-gateway:3.10'
+        - 'kong/kong-gateway:3.11'
         - 'kong/kong-gateway-dev:latest'
     env:
       KONG_ANONYMOUS_REPORTS: "off"


### PR DESCRIPTION
### Summary

In this PR, we are adding Enterprise Gateway v3.11 to the test matrix