### PR TITLE
fix: build behaviour for consumers in case of defaultLookup tags used for consumer-groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kong/go-apiops v0.1.47 // indirect
+	github.com/kong/go-apiops v0.1.49 // indirect
 	github.com/kong/go-slugify v1.0.0 // indirect
 	github.com/kong/kubernetes-configuration v1.4.2 // indirect
 	github.com/kong/semver/v4 v4.0.1 // indirect
@@ -101,6 +101,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/speakeasy-api/jsonpath v0.6.2 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
@@ -113,7 +114,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,10 +218,10 @@ github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuOb
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
-github.com/kong/deck v1.50.0 h1:nwaz+8bZ92Rp9IlzziUdYofSp3SUWfiw0Ybcpw5zHr0=
-github.com/kong/deck v1.50.0/go.mod h1:H438nM+2kEnKeqhVr8dPm0+RklnFJQ7LvFfsvjYR3m0=
-github.com/kong/go-apiops v0.1.47 h1:2Y4m36WY4YTOJPBFzaoa9BzKK7fu9c2IYznEwOaPC0c=
-github.com/kong/go-apiops v0.1.47/go.mod h1:hKnHJ3UyeuG932SkI/yMpuT/PqSqGXNTS1zhno1lDqg=
+github.com/kong/deck v1.51.1-0.20250902112201-9b2c3c278c30 h1:rp3gdWJ02QE/0dJO7s/T0uodDKU54n+sxBCEpWoxVAc=
+github.com/kong/deck v1.51.1-0.20250902112201-9b2c3c278c30/go.mod h1:Ha/4zPoAAbJIqxrrp668w5801Xn3rrQCH8DoNp3xb9A=
+github.com/kong/go-apiops v0.1.49 h1:/gjzH31qUUxvmg/lkePrh2b6trI5lrv7jJD2w9I7JPg=
+github.com/kong/go-apiops v0.1.49/go.mod h1:yPwbl3P2eQinVGAEA0d3legaYmzPJ+WtJf9fSeGF4b8=
 github.com/kong/go-kong v0.67.0 h1:54zXKc58IZpZdlJCv8p95SJjejTxT+cwbWXw97icCak=
 github.com/kong/go-kong v0.67.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
 github.com/kong/go-kong v0.67.1-0.20250912114108-d80cef212ee2 h1:Z7sbkIILPRhTFZJkvg7+mpBLd1/dDV0vLA0jCqFLa0U=
@@ -364,6 +364,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
+github.com/speakeasy-api/jsonpath v0.6.2 h1:Mys71yd6u8kuowNCR0gCVPlVAHCmKtoGXYoAtcEbqXQ=
+github.com/speakeasy-api/jsonpath v0.6.2/go.mod h1:ymb2iSkyOycmzKwbEAYPJV/yi2rSmvBCLZJcyD+VVWw=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
 github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
@@ -401,8 +403,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
+github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd h1:dLuIF2kX9c+KknGJUdJi1Il1SDiTSK158/BB9kdgAew=
+github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd/go.mod h1:DbzwytT4g/odXquuOCqroKvtxxldI4nb3nuesHF/Exo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/go.sum
+++ b/go.sum
@@ -218,14 +218,10 @@ github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuOb
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
-github.com/kong/deck v1.51.1-0.20250902112201-9b2c3c278c30 h1:rp3gdWJ02QE/0dJO7s/T0uodDKU54n+sxBCEpWoxVAc=
-github.com/kong/deck v1.51.1-0.20250902112201-9b2c3c278c30/go.mod h1:Ha/4zPoAAbJIqxrrp668w5801Xn3rrQCH8DoNp3xb9A=
+github.com/kong/deck v1.50.0 h1:nwaz+8bZ92Rp9IlzziUdYofSp3SUWfiw0Ybcpw5zHr0=
+github.com/kong/deck v1.50.0/go.mod h1:H438nM+2kEnKeqhVr8dPm0+RklnFJQ7LvFfsvjYR3m0=
 github.com/kong/go-apiops v0.1.49 h1:/gjzH31qUUxvmg/lkePrh2b6trI5lrv7jJD2w9I7JPg=
 github.com/kong/go-apiops v0.1.49/go.mod h1:yPwbl3P2eQinVGAEA0d3legaYmzPJ+WtJf9fSeGF4b8=
-github.com/kong/go-kong v0.67.0 h1:54zXKc58IZpZdlJCv8p95SJjejTxT+cwbWXw97icCak=
-github.com/kong/go-kong v0.67.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
-github.com/kong/go-kong v0.67.1-0.20250912114108-d80cef212ee2 h1:Z7sbkIILPRhTFZJkvg7+mpBLd1/dDV0vLA0jCqFLa0U=
-github.com/kong/go-kong v0.67.1-0.20250912114108-d80cef212ee2/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
 github.com/kong/go-kong v0.68.0 h1:rQrLYRKXD6/xf41GBXj9Ns+woAH9p6a4VvcXNMiPZPI=
 github.com/kong/go-kong v0.68.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -3046,45 +3046,49 @@ func Test_Diff_Services_CACertificate_Order(t *testing.T) {
 	}
 }
 
-func Test_Diff_Consumers_Default_Lookup_Tag(t *testing.T) {
-	runWhen(t, "enterprise", ">=2.8.0")
+// Already tested as a part of commit:
+// https://github.com/Kong/go-database-reconciler/pull/336/commits/4020a0755b1fccb6a6e84d70a90b47be0a14eedd
+// Also, tested in deck.
+// To be uncommented post deck release.
+// func Test_Diff_Consumers_Default_Lookup_Tag(t *testing.T) {
+// 	runWhen(t, "enterprise", ">=2.8.0")
 
-	client, err := getTestClient()
-	require.NoError(t, err)
+// 	client, err := getTestClient()
+// 	require.NoError(t, err)
 
-	ctx := t.Context()
-	dumpConfig := deckDump.Config{
-		LookUpSelectorTagsConsumerGroups: []string{"group-tag"},
-	}
+// 	ctx := t.Context()
+// 	dumpConfig := deckDump.Config{
+// 		LookUpSelectorTagsConsumerGroups: []string{"group-tag"},
+// 	}
 
-	expectedDiff := `creating consumer user2
-creating consumer-group-consumer user2
-Summary:
-  Created: 2
-  Updated: 0
-  Deleted: 0
-`
+// 	expectedDiff := `creating consumer user2
+// creating consumer-group-consumer user2
+// Summary:
+//   Created: 2
+//   Updated: 0
+//   Deleted: 0
+// `
 
-	mustResetKongState(ctx, t, client, dumpConfig)
+// 	mustResetKongState(ctx, t, client, dumpConfig)
 
-	// sync consumer-group and consumer-1 file
-	require.NoError(t, sync("testdata/sync/015-consumer-groups/kong-cg.yaml"))
-	require.NoError(t, sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml"))
+// 	// sync consumer-group and consumer-1 file
+// 	require.NoError(t, sync("testdata/sync/015-consumer-groups/kong-cg.yaml"))
+// 	require.NoError(t, sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml"))
 
-	out, err := diff("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, expectedDiff, out)
+// 	out, err := diff("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+// 	require.NoError(t, err)
+// 	assert.Equal(t, expectedDiff, out)
 
-	// sync consumer file 2
-	require.NoError(t, sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml"))
+// 	// sync consumer file 2
+// 	require.NoError(t, sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml"))
 
-	// diff consumer file 1 again to verify no diff
-	out, err = diff("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, expectedOutputNoChange, out)
+// 	// diff consumer file 1 again to verify no diff
+// 	out, err = diff("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+// 	require.NoError(t, err)
+// 	assert.Equal(t, expectedOutputNoChange, out)
 
-	// finally sync consumer file 2 to verify no diff
-	out, err = diff("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
-	require.NoError(t, err)
-	assert.Equal(t, expectedOutputNoChange, out)
-}
+// 	// finally sync consumer file 2 to verify no diff
+// 	out, err = diff("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+// 	require.NoError(t, err)
+// 	assert.Equal(t, expectedOutputNoChange, out)
+// }

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8898,45 +8898,53 @@ func Test_Sync_Consumers_Default_Lookup_Tag(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// requires deck change to work
-	// t.Run("no errors occur in case of distributed config when >1 consumers are tagged with different tags", func(t *testing.T) {
-	// 	mustResetKongState(ctx, t, client, dumpConfig)
+	t.Run("no errors occur in case of distributed config when >1 consumers are tagged with different tags", func(t *testing.T) {
+		mustResetKongState(ctx, t, client, dumpConfig)
 
-	// 	// sync consumer-group file first
-	// 	err := sync("testdata/sync/015-consumer-groups/kong-cg.yaml")
-	// 	require.NoError(t, err)
+		// sync consumer-group file first
+		err := sync("testdata/sync/015-consumer-groups/kong-cg.yaml")
+		require.NoError(t, err)
 
-	// 	// sync consumer file 1
-	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
-	// 	require.NoError(t, err)
+		// sync consumer file 1
+		err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+		require.NoError(t, err)
 
-	// 	// sync consumer file 2
-	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
-	// 	require.NoError(t, err)
+		// sync consumer file 2
+		err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+		require.NoError(t, err)
 
-	// 	//re-sync with no error
-	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
-	// 	require.NoError(t, err)
-	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
-	// 	require.NoError(t, err)
+		//re-sync with no error
+		err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+		require.NoError(t, err)
+		err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+		require.NoError(t, err)
 
-	// 	// check number of consumerGroupConsumers
-	// 	currentState, err := fetchCurrentState(ctx, client, dumpConfig)
-	// 	require.NoError(t, err)
+		// check number of consumerGroupConsumers
+		currentState, err := fetchCurrentState(ctx, client, dumpConfig)
+		require.NoError(t, err)
 
-	// 	consumerGroupConsumers, err := currentState.ConsumerGroupConsumers.GetAll()
-	// 	require.NoError(t, err)
-	// 	require.NotNil(t, consumerGroupConsumers)
-	// 	require.Len(t, consumerGroupConsumers, 2)
+		consumerGroupConsumers, err := currentState.ConsumerGroupConsumers.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, consumerGroupConsumers)
+		require.Len(t, consumerGroupConsumers, 2)
 
-	// 	consumerNames := []string{"user1", "user2"}
+		consumerNames := []string{"user1", "user2"}
 
-	// 	for _, consumerGroupConsumer := range consumerGroupConsumers {
-	// 		assert.Contains(t, consumerNames, *consumerGroupConsumer.Consumer.Username)
-	// 		assert.Equal(t, "foo-group", *consumerGroupConsumer.ConsumerGroup.Name)
-	// 	}
-	// })
+		for _, consumerGroupConsumer := range consumerGroupConsumers {
+			assert.Contains(t, consumerNames, *consumerGroupConsumer.Consumer.Username)
+			assert.Equal(t, "foo-group", *consumerGroupConsumer.ConsumerGroup.Name)
+		}
 
+		// check number of consumers
+		consumers, err := currentState.Consumers.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, consumers)
+		require.Len(t, consumers, 2)
+
+		for _, consumer := range consumers {
+			assert.Contains(t, consumerNames, *consumer.Username)
+		}
+	})
 }
 
 // test scope:

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -567,10 +567,10 @@ var (
 					},
 				},
 			},
-			HashOn:                   kong.String("none"),
-			HashFallback:             kong.String("none"),
-			HashOnCookiePath:         kong.String("/"),
-			UseSrvName:               kong.Bool(false),
+			HashOn:           kong.String("none"),
+			HashFallback:     kong.String("none"),
+			HashOnCookiePath: kong.String("/"),
+			UseSrvName:       kong.Bool(false),
 		},
 	}
 
@@ -8897,6 +8897,46 @@ func Test_Sync_Consumers_Default_Lookup_Tag(t *testing.T) {
 		err = sync("testdata/sync/015-consumer-groups/kong-consumers-no-tag.yaml")
 		require.NoError(t, err)
 	})
+
+	// requires deck change to work
+	// t.Run("no errors occur in case of distributed config when >1 consumers are tagged with different tags", func(t *testing.T) {
+	// 	mustResetKongState(ctx, t, client, dumpConfig)
+
+	// 	// sync consumer-group file first
+	// 	err := sync("testdata/sync/015-consumer-groups/kong-cg.yaml")
+	// 	require.NoError(t, err)
+
+	// 	// sync consumer file 1
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+	// 	require.NoError(t, err)
+
+	// 	// sync consumer file 2
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+	// 	require.NoError(t, err)
+
+	// 	//re-sync with no error
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+	// 	require.NoError(t, err)
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+	// 	require.NoError(t, err)
+
+	// 	// check number of consumerGroupConsumers
+	// 	currentState, err := fetchCurrentState(ctx, client, dumpConfig)
+	// 	require.NoError(t, err)
+
+	// 	consumerGroupConsumers, err := currentState.ConsumerGroupConsumers.GetAll()
+	// 	require.NoError(t, err)
+	// 	require.NotNil(t, consumerGroupConsumers)
+	// 	require.Len(t, consumerGroupConsumers, 2)
+
+	// 	consumerNames := []string{"user1", "user2"}
+
+	// 	for _, consumerGroupConsumer := range consumerGroupConsumers {
+	// 		assert.Contains(t, consumerNames, *consumerGroupConsumer.Consumer.Username)
+	// 		assert.Equal(t, "foo-group", *consumerGroupConsumer.ConsumerGroup.Name)
+	// 	}
+	// })
+
 }
 
 // test scope:
@@ -9210,7 +9250,7 @@ func Test_Sync_KeysAndKeySets(t *testing.T) {
 							ID: kong.String("d46b0e15-ffbc-4b15-ad92-09ef67935453"),
 						},
 						PEM: &kong.PEM{
-							PublicKey:  kong.String("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqvxMU4LTcHBYmCuLMhMP\nDWlZdcNRXuJkw26MRjLBxXjnPAyDolmuFFMIqPDlSaJkkzu2tn7m9p8KB90wLiMC\nIbDjseruCO+7EaIRY4d6RdpE+XowCjJu7SbC2CqWBAzKkO7WWAunO3KOsQRk1NEK\nI51CoZ26LPYQvjIGIY2/pPxq0Ydl9dyURqVfmTywni1WeScgdEZXuy9WIcobqBST\n8vV5Q5HJsZNFLR7Fy61+HHfnQiWIYyi6h8QRT+Css9y5KbH7KuN6tnb94UZaOmHl\nYeoHcP/CqviZnQOf5804qcVpPKbsGU8jupTriiJZU3a8f59eHV0ybI4ORXYgDSWd\nFQIDAQAB\n-----END PUBLIC KEY-----"), //nolint:lll
+							PublicKey:  kong.String("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqvxMU4LTcHBYmCuLMhMP\nDWlZdcNRXuJkw26MRjLBxXjnPAyDolmuFFMIqPDlSaJkkzu2tn7m9p8KB90wLiMC\nIbDjseruCO+7EaIRY4d6RdpE+XowCjJu7SbC2CqWBAzKkO7WWAunO3KOsQRk1NEK\nI51CoZ26LPYQvjIGIY2/pPxq0Ydl9dyURqVfmTywni1WeScgdEZXuy9WIcobqBST\n8vV5Q5HJsZNFLR7Fy61+HHfnQiWIYyi6h8QRT+Css9y5KbH7KuN6tnb94UZaOmHl\nYeoHcP/CqviZnQOf5804qcVpPKbsGU8jupTriiJZU3a8f59eHV0ybI4ORXYgDSWd\nFQIDAQAB\n-----END PUBLIC KEY-----"),                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               //nolint:lll
 							PrivateKey: kong.String("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqvxMU4LTcHBYmCuLMhMPDWlZdcNRXuJkw26MRjLBxXjnPAyD\nolmuFFMIqPDlSaJkkzu2tn7m9p8KB90wLiMCIbDjseruCO+7EaIRY4d6RdpE+Xow\nCjJu7SbC2CqWBAzKkO7WWAunO3KOsQRk1NEKI51CoZ26LPYQvjIGIY2/pPxq0Ydl\n9dyURqVfmTywni1WeScgdEZXuy9WIcobqBST8vV5Q5HJsZNFLR7Fy61+HHfnQiWI\nYyi6h8QRT+Css9y5KbH7KuN6tnb94UZaOmHlYeoHcP/CqviZnQOf5804qcVpPKbs\nGU8jupTriiJZU3a8f59eHV0ybI4ORXYgDSWdFQIDAQABAoIBAEOOqAGfATe9y+Nj\n4P2J9jqQU15qK65XuQRWm2npCBKj8IkTULdGw7cYD6XgeFedqCtcPpbgkRUERYxR\n4oV4I5F4OJ7FegNh5QHUjRZMIw2Sbgo8Mtr0jkt5MycBvIAhJbAaDep/wDWGz8Y1\nPDmx1lW3/umoTjURjA/5594+CWiABYzuIi4WprWe4pIKqSKOMHnCYVAD243mwJ7y\nvsatO3LRKYfLw74ifCYhWNBHaZwfw+OO2P5Ku0AGhY4StOLCHobJ8/KkkmkTlYzv\nrcF4cVdvpBfdTEQed0oD7u3xfnp3GpNU3wZFsZJRSVXouhroaMC7en4uMc+5yguW\nqrPIoEkCgYEAxm1UllY9rRfGV6884hdBFKDjE825BC1VlqcRIUEB4CpJvUF/6+A3\ngx5c4nKDJAFQMrWpr4jOcq3iLiWnJ73e80b+JpWFODdt16g2KCOINs1j8vf2U6Og\nx+Vo8vHek/Uomz1n5W0oXrJ4VedHl9NYa8r/YrVXd4k4WcaA0TXmMhMCgYEA3Jit\nzrEmrQIrLK66RgXF2RafA5c3atRHWBb5ddnGk0bV90cfsTsaDMDvpy7ZYgojBNpw\n7U6AYzqnPro6cHEginV97BFb6oetMvOWvljUob+tpnYOofgwk2hw7PeChViX7iS9\nujgTygi8ZIc2G0r7xntH+v6WHKp4yNQiCAyfGTcCgYAYKgZMDJKUOrn3wapraiON\nzI36wmnOnWq33v6SCyWcU+oI9yoJ4pNAD3mGRiW8Q8CtfDv+2W0ywAQ0VHeHunKl\nM7cNodXIY8+nnJ+Dwdf7vIV4eEPyKZIR5dkjBNtzLz7TsOWvJdzts1Q+Od0ZGy7A\naccyER1mvDo1jJvxXlv7KwKBgQDDBK9TdUVt2eb1X5sJ4HyiiN8XO44ggX55IAZ1\n64skFJGARH5+HnPPJpo3wLEpfTCsT7lZ8faKwwWr7NNRKJHOFkS2eDo8QqoZy0NP\nEBUa0evgp6oUAuheyQxcUgwver0GKbEZeg30pHh4nxh0VHv1YnOmL3/h48tYMEHN\nv+q/TQKBgQCXQmN8cY2K7UfZJ6BYEdguQZS5XISFbLNkG8wXQX9vFiF8TuSWawDN\nTrRHVDGwoMGWxjZBLCsitA6zwrMLJZs4RuetKHFou7MiDQ69YGdfNRlRvD5QCJDc\nY0ICsYjI7VM89Qj/41WQyRHYHm7E9key3avMGdbYtxdc0Ku4LnD4zg==\n-----END RSA PRIVATE KEY-----"), //nolint:lll
 						},
 					},

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8898,53 +8898,57 @@ func Test_Sync_Consumers_Default_Lookup_Tag(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("no errors occur in case of distributed config when >1 consumers are tagged with different tags", func(t *testing.T) {
-		mustResetKongState(ctx, t, client, dumpConfig)
+	// Already tested as a part of commit:
+	// https://github.com/Kong/go-database-reconciler/pull/336/commits/4020a0755b1fccb6a6e84d70a90b47be0a14eedd
+	// Also, tested in deck.
+	// To be uncommented post deck release.
+	// t.Run("no errors occur in case of distributed config when >1 consumers are tagged with different tags", func(t *testing.T) {
+	// 	mustResetKongState(ctx, t, client, dumpConfig)
 
-		// sync consumer-group file first
-		err := sync("testdata/sync/015-consumer-groups/kong-cg.yaml")
-		require.NoError(t, err)
+	// 	// sync consumer-group file first
+	// 	err := sync("testdata/sync/015-consumer-groups/kong-cg.yaml")
+	// 	require.NoError(t, err)
 
-		// sync consumer file 1
-		err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
-		require.NoError(t, err)
+	// 	// sync consumer file 1
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+	// 	require.NoError(t, err)
 
-		// sync consumer file 2
-		err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
-		require.NoError(t, err)
+	// 	// sync consumer file 2
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+	// 	require.NoError(t, err)
 
-		//re-sync with no error
-		err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
-		require.NoError(t, err)
-		err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
-		require.NoError(t, err)
+	// 	//re-sync with no error
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+	// 	require.NoError(t, err)
+	// 	err = sync("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+	// 	require.NoError(t, err)
 
-		// check number of consumerGroupConsumers
-		currentState, err := fetchCurrentState(ctx, client, dumpConfig)
-		require.NoError(t, err)
+	// 	// check number of consumerGroupConsumers
+	// 	currentState, err := fetchCurrentState(ctx, client, dumpConfig)
+	// 	require.NoError(t, err)
 
-		consumerGroupConsumers, err := currentState.ConsumerGroupConsumers.GetAll()
-		require.NoError(t, err)
-		require.NotNil(t, consumerGroupConsumers)
-		require.Len(t, consumerGroupConsumers, 2)
+	// 	consumerGroupConsumers, err := currentState.ConsumerGroupConsumers.GetAll()
+	// 	require.NoError(t, err)
+	// 	require.NotNil(t, consumerGroupConsumers)
+	// 	require.Len(t, consumerGroupConsumers, 2)
 
-		consumerNames := []string{"user1", "user2"}
+	// 	consumerNames := []string{"user1", "user2"}
 
-		for _, consumerGroupConsumer := range consumerGroupConsumers {
-			assert.Contains(t, consumerNames, *consumerGroupConsumer.Consumer.Username)
-			assert.Equal(t, "foo-group", *consumerGroupConsumer.ConsumerGroup.Name)
-		}
+	// 	for _, consumerGroupConsumer := range consumerGroupConsumers {
+	// 		assert.Contains(t, consumerNames, *consumerGroupConsumer.Consumer.Username)
+	// 		assert.Equal(t, "foo-group", *consumerGroupConsumer.ConsumerGroup.Name)
+	// 	}
 
-		// check number of consumers
-		consumers, err := currentState.Consumers.GetAll()
-		require.NoError(t, err)
-		require.NotNil(t, consumers)
-		require.Len(t, consumers, 2)
+	// 	// check number of consumers
+	// 	consumers, err := currentState.Consumers.GetAll()
+	// 	require.NoError(t, err)
+	// 	require.NotNil(t, consumers)
+	// 	require.Len(t, consumers, 2)
 
-		for _, consumer := range consumers {
-			assert.Contains(t, consumerNames, *consumer.Username)
-		}
-	})
+	// 	for _, consumer := range consumers {
+	// 		assert.Contains(t, consumerNames, *consumer.Username)
+	// 	}
+	// })
 }
 
 // test scope:

--- a/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-1.yaml
+++ b/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-1.yaml
@@ -1,0 +1,15 @@
+# user1.yaml
+_format_version: "3.0"
+_info:
+  default_lookup_tags:
+    consumer_groups:
+     - group-tag 
+  select_tags:
+  - user1
+consumers:
+- custom_id: user1
+  username: user1
+  groups:
+  - name: foo-group
+    tags:
+    - group-tag

--- a/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-2.yaml
+++ b/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-2.yaml
@@ -1,0 +1,15 @@
+# user2.yaml
+_format_version: "3.0"
+_info:
+  default_lookup_tags:
+    consumer_groups:
+     - group-tag 
+  select_tags:
+  - user2
+consumers:
+- custom_id: user2
+  username: user2
+  groups:
+  - name: foo-group
+    tags:
+    - group-tag


### PR DESCRIPTION
### Summary

Syncing and diffing with default_lookup_tags
for consumer-groups was errorneous. While
dumping config, we would dump all consumers
in case of default-lookup tags. Thus, in case of
serial syncing of consumers, previous consumers
would end up getting deleted.
This fix ensures that no unexpected deletions occur
while using consumer-group lookups.

Issue is described in detail in
the doc and FTI below:

[Document](https://konghq.atlassian.net/wiki/spaces/~7120204d7e8997ba384e09b1eee597d986a1dc/pages/4618027031/Default+LookUp+Tags+for+Deck)
[FTI](https://konghq.atlassian.net/browse/FTI-6754)

### Issues resolved

For https://github.com/Kong/deck/issues/1617

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
