### PR TITLE
feat: support nested array in plugin config

### DIFF
--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -656,10 +656,10 @@ func (e EmptyInterfaceUsingUnderlyingType) Less(i, j int) bool {
 			return strconv.Itoa(v)
 		case float64:
 			return strconv.FormatFloat(v, 'f', -1, 64)
-		case map[string]interface{}:
+		case map[string]interface{}, []interface{}:
 			jsonBytes, err := json.Marshal(v)
 			if err != nil {
-				panic(fmt.Sprintf("error converting map to JSON string: %v", err))
+				panic(fmt.Sprintf("error converting map or array to JSON string: %v", err))
 			}
 			return string(jsonBytes)
 		default:

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -679,10 +679,13 @@ func sortNestedArrays(m map[string]interface{}) map[string]interface{} {
 	for k, v := range m {
 		switch value := v.(type) {
 		case []interface{}:
-			// Recursively sort each element if it's a map
+			// Recursively sort each element if it's a map or array
 			for i, elem := range value {
-				if elemMap, ok := elem.(map[string]interface{}); ok {
-					value[i] = sortNestedArrays(elemMap)
+				switch elemType := elem.(type) {
+				case map[string]interface{}:
+					value[i] = sortNestedArrays(elemType)
+				case []interface{}:
+					value[i] = sortArrayElementsRecursively(elemType)
 				}
 			}
 			sort.Sort(EmptyInterfaceUsingUnderlyingType(value))
@@ -695,6 +698,21 @@ func sortNestedArrays(m map[string]interface{}) map[string]interface{} {
 	}
 
 	return sortedMap
+}
+
+// Helper function to sort array elements recursively
+func sortArrayElementsRecursively(arr []interface{}) []interface{} {
+	for i, elem := range arr {
+		switch elemType := elem.(type) {
+		case map[string]interface{}:
+			arr[i] = sortNestedArrays(elemType)
+		case []interface{}:
+			arr[i] = sortArrayElementsRecursively(elemType)
+		}
+	}
+
+	sort.Sort(EmptyInterfaceUsingUnderlyingType(arr))
+	return arr
 }
 
 // Consumer represents a consumer in Kong.

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -3092,3 +3092,21 @@ func Test_Diff_Services_CACertificate_Order(t *testing.T) {
 // 	require.NoError(t, err)
 // 	assert.Equal(t, expectedOutputNoChange, out)
 // }
+
+func Test_Diff_PluginConfig_Nested_Arrays(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.12.0")
+	client, err := getTestClient()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	kongFile := "testdata/sync/003-create-a-plugin/plugin-nested-array.yaml"
+
+	mustResetKongState(ctx, t, client, deckDump.Config{})
+	require.NoError(t, sync(kongFile))
+
+	// diff with an element order change inside the nested array
+	diffFile := "testdata/sync/003-create-a-plugin/plugin-nested-array-reordered.yaml"
+	out, err := diff(diffFile)
+	require.NoError(t, err)
+	assert.Equal(t, expectedOutputNoChange, out)
+}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -9423,3 +9423,18 @@ func Test_Sync_SkipCustomEntitiesWithSelectorTags(t *testing.T) {
 		})
 	}
 }
+
+func Test_Sync_PluginConfig_Nested_Arrays(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.12.0")
+	client, err := getTestClient()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	kongFile := "testdata/sync/003-create-a-plugin/plugin-nested-array.yaml"
+
+	mustResetKongState(ctx, t, client, deckDump.Config{})
+	require.NoError(t, sync(kongFile))
+
+	// resync with no error
+	require.NoError(t, sync(kongFile))
+}

--- a/tests/integration/testdata/sync/003-create-a-plugin/plugin-nested-array-reordered.yaml
+++ b/tests/integration/testdata/sync/003-create-a-plugin/plugin-nested-array-reordered.yaml
@@ -1,0 +1,235 @@
+
+_format_version: "3.0"
+plugins:
+- name: jwt-signer
+  config:
+    access_token_audience_claim:
+    - aud
+    access_token_audiences_allowed:
+    - aud1
+    - aud2
+    access_token_consumer_by:
+    - username
+    - custom_id
+    access_token_consumer_claim: null
+    access_token_expiry_claim:
+    - exp
+    access_token_introspection_audience_claim:
+    - aud
+    access_token_introspection_audiences_allowed:
+    - aud1
+    - aud2
+    access_token_introspection_authorization: null
+    access_token_introspection_body_args: null
+    access_token_introspection_consumer_by:
+    - username
+    - custom_id
+    access_token_introspection_consumer_claim: null
+    access_token_introspection_endpoint: null
+    access_token_introspection_expiry_claim:
+    - exp
+    access_token_introspection_hint: access_token
+    access_token_introspection_issuer_claim:
+    - iss
+    access_token_introspection_issuers_allowed:
+    - iss1
+    - iss2
+    access_token_introspection_jwt_claim: null
+    access_token_introspection_leeway: 0
+    access_token_introspection_notbefore_claim:
+    - nbf
+    access_token_introspection_optional_claims:
+    - ['aud']
+    access_token_introspection_required_claims:
+    - ['exp']
+    - ['iss']
+    access_token_introspection_scopes_claim:
+    - scope
+    access_token_introspection_scopes_required: null
+    access_token_introspection_subject_claim:
+    - sub
+    access_token_introspection_subjects_allowed:
+    - sub1
+    - sub2
+    access_token_introspection_timeout: null
+    access_token_issuer: kong
+    access_token_issuer_claim:
+    - iss1
+    - iss2
+    access_token_issuers_allowed:
+    - test
+    access_token_jwks_uri: https://example.com
+    access_token_jwks_uri_client_certificate: null
+    access_token_jwks_uri_client_password: null
+    access_token_jwks_uri_client_username: null
+    access_token_jwks_uri_rotate_period: 0
+    access_token_keyset: kong
+    access_token_keyset_client_certificate: null
+    access_token_keyset_client_password: null
+    access_token_keyset_client_username: null
+    access_token_keyset_rotate_period: 0
+    access_token_leeway: 0
+    access_token_notbefore_claim:
+    - nbf
+    access_token_optional: false
+    access_token_optional_claims:
+    - - aud
+    access_token_request_header: Authorization
+    access_token_required_claims:
+    - - exp
+    - - iss
+    access_token_scopes_claim:
+    - scope
+    access_token_scopes_required: null
+    access_token_signing: false
+    access_token_signing_algorithm: RS256
+    access_token_subject_claim:
+    - sub
+    access_token_subjects_allowed:
+    - sub1
+    - sub2
+    access_token_upstream_header: XXX:bearer
+    access_token_upstream_leeway: 0
+    add_access_token_claims: {}
+    add_channel_token_claims: {}
+    add_claims: {}
+    cache_access_token_introspection: true
+    cache_channel_token_introspection: true
+    channel_token_audience_claim:
+    - aud
+    channel_token_audiences_allowed:
+    - aud1
+    - aud2
+    channel_token_consumer_by:
+    - username
+    - custom_id
+    channel_token_consumer_claim: null
+    channel_token_expiry_claim:
+    - exp
+    channel_token_introspection_audience_claim:
+    - aud
+    channel_token_introspection_audiences_allowed:
+    - aud1
+    - aud2
+    channel_token_introspection_authorization: null
+    channel_token_introspection_body_args: null
+    channel_token_introspection_consumer_by:
+    - username
+    - custom_id
+    channel_token_introspection_consumer_claim: null
+    channel_token_introspection_endpoint: null
+    channel_token_introspection_expiry_claim:
+    - exp
+    channel_token_introspection_hint: null
+    channel_token_introspection_issuer_claim:
+    - iss
+    channel_token_introspection_issuers_allowed:
+    - iss1
+    - iss2
+    channel_token_introspection_jwt_claim: null
+    channel_token_introspection_leeway: 0
+    channel_token_introspection_notbefore_claim:
+    - nbf
+    channel_token_introspection_optional_claims:
+    - - aud
+    channel_token_introspection_required_claims:
+    - - exp
+    # element order changed here
+    - - sub
+      - iss
+    - - sub
+    channel_token_introspection_scopes_claim:
+    - scope
+    channel_token_introspection_scopes_required: null
+    channel_token_introspection_subject_claim:
+    - sub
+    channel_token_introspection_subjects_allowed:
+    # element order changed here
+    - sub2
+    - sub1
+    channel_token_introspection_timeout: null
+    channel_token_issuer: kong
+    channel_token_issuer_claim:
+    - iss1
+    - iss2
+    channel_token_issuers_allowed:
+    - test
+    channel_token_jwks_uri: null
+    channel_token_jwks_uri_client_certificate: null
+    channel_token_jwks_uri_client_password: null
+    channel_token_jwks_uri_client_username: null
+    channel_token_jwks_uri_rotate_period: 0
+    channel_token_keyset: kong
+    channel_token_keyset_client_certificate: null
+    channel_token_keyset_client_password: null
+    channel_token_keyset_client_username: null
+    channel_token_keyset_rotate_period: 0
+    channel_token_leeway: 0
+    channel_token_notbefore_claim:
+    - nbf
+    channel_token_optional: true
+    channel_token_optional_claims:
+    - - aud
+    channel_token_request_header: null
+    channel_token_required_claims:
+    - - exp
+    - - iss
+    channel_token_scopes_claim:
+    - scope
+    channel_token_scopes_required: null
+    channel_token_signing: false
+    channel_token_signing_algorithm: RS256
+    channel_token_subject_claim:
+    - sub
+    channel_token_subjects_allowed:
+    - sub1
+    - sub2
+    channel_token_upstream_header: ZZZ:bearer
+    channel_token_upstream_leeway: 0
+    enable_access_token_introspection: true
+    enable_channel_token_introspection: true
+    enable_hs_signatures: false
+    enable_instrumentation: false
+    original_access_token_upstream_header: YYY:bearer
+    original_channel_token_upstream_header: null
+    realm: null
+    remove_access_token_claims: []
+    remove_channel_token_claims: []
+    set_access_token_claims: {}
+    set_channel_token_claims: {}
+    set_claims: {}
+    trust_access_token_introspection: true
+    trust_channel_token_introspection: true
+    verify_access_token_audience: true
+    verify_access_token_expiry: true
+    verify_access_token_introspection_audience: true
+    verify_access_token_introspection_expiry: true
+    verify_access_token_introspection_issuer: true
+    verify_access_token_introspection_notbefore: true
+    verify_access_token_introspection_scopes: true
+    verify_access_token_introspection_subject: true
+    verify_access_token_issuer: true
+    verify_access_token_notbefore: true
+    verify_access_token_scopes: true
+    verify_access_token_signature: false
+    verify_access_token_subject: true
+    verify_channel_token_audience: true
+    verify_channel_token_expiry: true
+    verify_channel_token_introspection_audience: true
+    verify_channel_token_introspection_expiry: true
+    verify_channel_token_introspection_issuer: true
+    verify_channel_token_introspection_notbefore: true
+    verify_channel_token_introspection_scopes: true
+    verify_channel_token_introspection_subject: true
+    verify_channel_token_issuer: true
+    verify_channel_token_notbefore: true
+    verify_channel_token_scopes: true
+    verify_channel_token_signature: false
+    verify_channel_token_subject: true
+  enabled: true
+  protocols:
+    - grpc
+    - grpcs
+    - http
+    - https
+    

--- a/tests/integration/testdata/sync/003-create-a-plugin/plugin-nested-array.yaml
+++ b/tests/integration/testdata/sync/003-create-a-plugin/plugin-nested-array.yaml
@@ -1,0 +1,233 @@
+
+_format_version: "3.0"
+plugins:
+- name: jwt-signer
+  config:
+    access_token_audience_claim:
+    - aud
+    access_token_audiences_allowed:
+    - aud1
+    - aud2
+    access_token_consumer_by:
+    - username
+    - custom_id
+    access_token_consumer_claim: null
+    access_token_expiry_claim:
+    - exp
+    access_token_introspection_audience_claim:
+    - aud
+    access_token_introspection_audiences_allowed:
+    - aud1
+    - aud2
+    access_token_introspection_authorization: null
+    access_token_introspection_body_args: null
+    access_token_introspection_consumer_by:
+    - username
+    - custom_id
+    access_token_introspection_consumer_claim: null
+    access_token_introspection_endpoint: null
+    access_token_introspection_expiry_claim:
+    - exp
+    access_token_introspection_hint: access_token
+    access_token_introspection_issuer_claim:
+    - iss
+    access_token_introspection_issuers_allowed:
+    - iss1
+    - iss2
+    access_token_introspection_jwt_claim: null
+    access_token_introspection_leeway: 0
+    access_token_introspection_notbefore_claim:
+    - nbf
+    access_token_introspection_optional_claims:
+    - ['aud']
+    access_token_introspection_required_claims:
+    - ['exp']
+    - ['iss']
+    access_token_introspection_scopes_claim:
+    - scope
+    access_token_introspection_scopes_required: null
+    access_token_introspection_subject_claim:
+    - sub
+    access_token_introspection_subjects_allowed:
+    - sub1
+    - sub2
+    access_token_introspection_timeout: null
+    access_token_issuer: kong
+    access_token_issuer_claim:
+    - iss1
+    - iss2
+    access_token_issuers_allowed:
+    - test
+    access_token_jwks_uri: https://example.com
+    access_token_jwks_uri_client_certificate: null
+    access_token_jwks_uri_client_password: null
+    access_token_jwks_uri_client_username: null
+    access_token_jwks_uri_rotate_period: 0
+    access_token_keyset: kong
+    access_token_keyset_client_certificate: null
+    access_token_keyset_client_password: null
+    access_token_keyset_client_username: null
+    access_token_keyset_rotate_period: 0
+    access_token_leeway: 0
+    access_token_notbefore_claim:
+    - nbf
+    access_token_optional: false
+    access_token_optional_claims:
+    - - aud
+    access_token_request_header: Authorization
+    access_token_required_claims:
+    - - exp
+    - - iss
+    access_token_scopes_claim:
+    - scope
+    access_token_scopes_required: null
+    access_token_signing: false
+    access_token_signing_algorithm: RS256
+    access_token_subject_claim:
+    - sub
+    access_token_subjects_allowed:
+    - sub1
+    - sub2
+    access_token_upstream_header: XXX:bearer
+    access_token_upstream_leeway: 0
+    add_access_token_claims: {}
+    add_channel_token_claims: {}
+    add_claims: {}
+    cache_access_token_introspection: true
+    cache_channel_token_introspection: true
+    channel_token_audience_claim:
+    - aud
+    channel_token_audiences_allowed:
+    - aud1
+    - aud2
+    channel_token_consumer_by:
+    - username
+    - custom_id
+    channel_token_consumer_claim: null
+    channel_token_expiry_claim:
+    - exp
+    channel_token_introspection_audience_claim:
+    - aud
+    channel_token_introspection_audiences_allowed:
+    - aud1
+    - aud2
+    channel_token_introspection_authorization: null
+    channel_token_introspection_body_args: null
+    channel_token_introspection_consumer_by:
+    - username
+    - custom_id
+    channel_token_introspection_consumer_claim: null
+    channel_token_introspection_endpoint: null
+    channel_token_introspection_expiry_claim:
+    - exp
+    channel_token_introspection_hint: null
+    channel_token_introspection_issuer_claim:
+    - iss
+    channel_token_introspection_issuers_allowed:
+    - iss1
+    - iss2
+    channel_token_introspection_jwt_claim: null
+    channel_token_introspection_leeway: 0
+    channel_token_introspection_notbefore_claim:
+    - nbf
+    channel_token_introspection_optional_claims:
+    - - aud
+    channel_token_introspection_required_claims:
+    - - exp
+    - - iss
+      - sub
+    - - sub
+    channel_token_introspection_scopes_claim:
+    - scope
+    channel_token_introspection_scopes_required: null
+    channel_token_introspection_subject_claim:
+    - sub
+    channel_token_introspection_subjects_allowed:
+    - sub1
+    - sub2
+    channel_token_introspection_timeout: null
+    channel_token_issuer: kong
+    channel_token_issuer_claim:
+    - iss1
+    - iss2
+    channel_token_issuers_allowed:
+    - test
+    channel_token_jwks_uri: null
+    channel_token_jwks_uri_client_certificate: null
+    channel_token_jwks_uri_client_password: null
+    channel_token_jwks_uri_client_username: null
+    channel_token_jwks_uri_rotate_period: 0
+    channel_token_keyset: kong
+    channel_token_keyset_client_certificate: null
+    channel_token_keyset_client_password: null
+    channel_token_keyset_client_username: null
+    channel_token_keyset_rotate_period: 0
+    channel_token_leeway: 0
+    channel_token_notbefore_claim:
+    - nbf
+    channel_token_optional: true
+    channel_token_optional_claims:
+    - - aud
+    channel_token_request_header: null
+    channel_token_required_claims:
+    - - exp
+    - - iss
+    channel_token_scopes_claim:
+    - scope
+    channel_token_scopes_required: null
+    channel_token_signing: false
+    channel_token_signing_algorithm: RS256
+    channel_token_subject_claim:
+    - sub
+    channel_token_subjects_allowed:
+    - sub1
+    - sub2
+    channel_token_upstream_header: ZZZ:bearer
+    channel_token_upstream_leeway: 0
+    enable_access_token_introspection: true
+    enable_channel_token_introspection: true
+    enable_hs_signatures: false
+    enable_instrumentation: false
+    original_access_token_upstream_header: YYY:bearer
+    original_channel_token_upstream_header: null
+    realm: null
+    remove_access_token_claims: []
+    remove_channel_token_claims: []
+    set_access_token_claims: {}
+    set_channel_token_claims: {}
+    set_claims: {}
+    trust_access_token_introspection: true
+    trust_channel_token_introspection: true
+    verify_access_token_audience: true
+    verify_access_token_expiry: true
+    verify_access_token_introspection_audience: true
+    verify_access_token_introspection_expiry: true
+    verify_access_token_introspection_issuer: true
+    verify_access_token_introspection_notbefore: true
+    verify_access_token_introspection_scopes: true
+    verify_access_token_introspection_subject: true
+    verify_access_token_issuer: true
+    verify_access_token_notbefore: true
+    verify_access_token_scopes: true
+    verify_access_token_signature: false
+    verify_access_token_subject: true
+    verify_channel_token_audience: true
+    verify_channel_token_expiry: true
+    verify_channel_token_introspection_audience: true
+    verify_channel_token_introspection_expiry: true
+    verify_channel_token_introspection_issuer: true
+    verify_channel_token_introspection_notbefore: true
+    verify_channel_token_introspection_scopes: true
+    verify_channel_token_introspection_subject: true
+    verify_channel_token_issuer: true
+    verify_channel_token_notbefore: true
+    verify_channel_token_scopes: true
+    verify_channel_token_signature: false
+    verify_channel_token_subject: true
+  enabled: true
+  protocols:
+    - grpc
+    - grpcs
+    - http
+    - https
+    


### PR DESCRIPTION
### Summary

This change ensures that plugins
can be configured with nested arrays.
A test-case is added that shows two ways
of adding array of arrays.

Way 1:
```
config:
   fieldName:
   - - item1
   - - item2
```

Way 2:
```
config:
   fieldName:
   - ['item1']
   - ['item2']
```

Both ways are valid yaml and supported by deck.

### Issues resolved

For https://github.com/Kong/deck/issues/1740

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
