### PR TITLE
fix: handle jwt-secrets exception to create valid dump

### DIFF
--- a/pkg/dump/skip_defaults.go
+++ b/pkg/dump/skip_defaults.go
@@ -335,7 +335,7 @@ func removeDefaultsFromEntity(entity interface{}, entityType string, schemaFetch
 		return nil
 	}
 
-	defaultFields = handleExceptions(entityType, entityIdentifier, defaultFields)
+	defaultFields = handleExceptions(entityType, defaultFields)
 
 	err = stripDefaultValuesFromEntity(v, defaultFields)
 	if err != nil {
@@ -345,7 +345,7 @@ func removeDefaultsFromEntity(entity interface{}, entityType string, schemaFetch
 	return nil
 }
 
-func handleExceptions(entityType string, entityIdentifier string, defaultFields map[string]interface{}) map[string]interface{} {
+func handleExceptions(entityType string, defaultFields map[string]interface{}) map[string]interface{} {
 	// Don't skip default for "algorithm" field in jwt_secrets
 	if entityType == "jwt_secrets" {
 		delete(defaultFields, "algorithm")


### PR DESCRIPTION
### Summary

`jwt_secrets` require "algorithm" field
to be filled in for the sync to go through
without errors. Hence, adding an exception for
it in in the skip-defaults section.

Test PR for gateway: https://github.com/Kong/deck/pull/1799

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
