### PR TITLE
feat: added skip-defaults for konnect vaults

### DIFF
--- a/pkg/dump/schemas.go
+++ b/pkg/dump/schemas.go
@@ -43,8 +43,7 @@ func NewSchemaFetcher(ctx context.Context, client *kong.Client, isKonnect bool) 
 		vaultSchemaCache: types.NewSchemaCache(func(ctx context.Context,
 			vaultType string,
 		) (map[string]interface{}, error) {
-			// works only for gateway, not konnect
-			return getVaultSchema(ctx, client, vaultType)
+			return getVaultSchema(ctx, client, vaultType, isKonnect)
 		}),
 	}
 }
@@ -127,8 +126,12 @@ func getKonnectEntitySchema(ctx context.Context, client *kong.Client, entityType
 	return schema, nil
 }
 
-func getVaultSchema(ctx context.Context, client *kong.Client, vaultType string) (kong.Schema, error) {
+func getVaultSchema(ctx context.Context, client *kong.Client, vaultType string, isKonnect bool) (kong.Schema, error) {
 	var schema map[string]interface{}
+
+	if isKonnect {
+		return getKonnectVaultSchema(ctx, client, vaultType)
+	}
 
 	endpoint := fmt.Sprintf("/schemas/vaults/%s", vaultType)
 	req, err := client.NewRequest(http.MethodGet, endpoint, nil, nil)
@@ -141,6 +144,92 @@ func getVaultSchema(ctx context.Context, client *kong.Client, vaultType string) 
 	}
 	if err != nil {
 		return schema, fmt.Errorf("failed to fetch schema: %w", err)
+	}
+
+	return schema, nil
+}
+
+func getKonnectVaultSchema(ctx context.Context, client *kong.Client, vaultType string) (kong.Schema, error) {
+	var schema map[string]interface{}
+
+	fullSchema, err := getKonnectEntitySchema(ctx, client, "vaults")
+	if err != nil {
+		return schema, fmt.Errorf("failed to fetch schema: %w", err)
+	}
+
+	// Start with the base schema from fullSchema
+	schema = make(map[string]interface{})
+	for key, value := range fullSchema {
+		if key != "allOf" {
+			schema[key] = value
+		}
+	}
+
+	// Extract the specific vault type schema from the full schema
+	// The full schema contains conditional logic based on vault name
+	// We need to find the matching condition for the given vaultType
+	allOf, ok := fullSchema["allOf"].([]interface{})
+	if !ok {
+		return schema, fmt.Errorf("invalid schema format: allOf not found or not an array")
+	}
+
+	const (
+		ifKey         = "if"
+		thenKey       = "then"
+		propertiesKey = "properties"
+		nameKey       = "name"
+		constKey      = "const"
+		configKey     = "config"
+	)
+
+	// Look for the matching vault type in the conditional schemas
+	for _, condition := range allOf {
+		conditionMap, ok := condition.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Check if this condition matches our vault type
+		if ifClause, exists := conditionMap[ifKey]; exists {
+			if ifMap, ok := ifClause.(map[string]interface{}); ok {
+				if properties, exists := ifMap[propertiesKey]; exists {
+					if propsMap, ok := properties.(map[string]interface{}); ok {
+						if nameClause, exists := propsMap[nameKey]; exists {
+							if nameMap, ok := nameClause.(map[string]interface{}); ok {
+								if constValue, exists := nameMap[constKey]; exists {
+									if constStr, ok := constValue.(string); ok && constStr == vaultType {
+										// Found the matching condition, extract the config from "then" clause
+										if thenClause, exists := conditionMap[thenKey]; exists {
+											if thenMap, ok := thenClause.(map[string]interface{}); ok {
+												if thenProps, exists := thenMap[propertiesKey]; exists {
+													if thenPropsMap, ok := thenProps.(map[string]interface{}); ok {
+														if configSchema, exists := thenPropsMap[configKey]; exists {
+															if configSchemaMap, ok := configSchema.(map[string]interface{}); ok {
+																if configProps, exists := configSchemaMap[propertiesKey]; exists {
+																	if configPropsMap, ok := configProps.(map[string]interface{}); ok {
+																		vaultConfigSchema := configPropsMap[vaultType]
+																		if schemaProps, exists := schema[propertiesKey]; exists {
+																			if schemaPropsMap, ok := schemaProps.(map[string]interface{}); ok {
+																				schemaPropsMap[configKey] = vaultConfigSchema
+																			}
+																		}
+																		return schema, nil
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	return schema, nil

--- a/pkg/utils/kongToKonnectEntities.go
+++ b/pkg/utils/kongToKonnectEntities.go
@@ -17,4 +17,5 @@ var KongToKonnectEntitiesMap = map[string]string{
 	"basicauth_credentials": "basic-auth",
 	"mtls_auth_credentials": "mtls-auth",
 	"snis":                  "sni",
+	"vaults":                "vault",
 }


### PR DESCRIPTION
### Summary

At the moment, konnect dumps the a vault schema with conditions
added in it to parse for a specific vault type.
Gateway doesn't have this issue. So, we can query for a vault-type
directly there. There's an issue filed with koko team to get separate
endpoints for each vault type. Till that is not resolved, I have added a
parser to fetch the config schema for a vault-type.

Tests would be added in this PR: https://github.com/Kong/deck/pull/1804
Konnect test: https://github.com/Kong/deck/actions/runs/19031820505/job/54348435093

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
