### PR TITLE
fix: --skip-defaults flag with dump config should print zero-values set by user

### DIFF
--- a/pkg/dump/skip_defaults.go
+++ b/pkg/dump/skip_defaults.go
@@ -711,6 +711,11 @@ func compareMaps(fieldMap, defaultMap reflect.Value) interface{} {
 			continue // Skip unexported fields
 		}
 
+		if fieldVal.IsZero() && !defaultVal.IsZero() {
+			newMap[key.String()] = fieldVal.Interface()
+			continue
+		}
+
 		fieldVal = reflect.ValueOf(fieldVal.Interface())
 		defaultVal = reflect.ValueOf(defaultVal.Interface())
 

--- a/pkg/dump/skip_defaults_test.go
+++ b/pkg/dump/skip_defaults_test.go
@@ -647,6 +647,22 @@ func TestCompareMaps(t *testing.T) {
 			},
 			expected: map[string]interface{}{},
 		},
+		{
+			name: "field has zero value for non-zero/not-defined defaults",
+			fieldMap: map[string]interface{}{
+				"host":       nil,
+				"jwk_arrays": []interface{}{},
+				"name":       "test",
+			},
+			defaultMap: map[string]interface{}{
+				"host": "localhost",
+			},
+			expected: map[string]interface{}{
+				"host":       nil,
+				"name":       "test",
+				"jwk_arrays": []interface{}{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary

A field that has non-zero default value, say `host: localhost`, and a user sets it null, should be printed in the dump config, 
if --skip-defaults is passed.

### Issues resolved

For https://github.com/Kong/deck/issues/1824

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
