### PR TITLE
Revert "fix: --skip-defaults flag with dump config should print zero-values set by user"

### DIFF
--- a/pkg/dump/skip_defaults.go
+++ b/pkg/dump/skip_defaults.go
@@ -711,11 +711,6 @@ func compareMaps(fieldMap, defaultMap reflect.Value) interface{} {
 			continue // Skip unexported fields
 		}
 
-		if fieldVal.IsZero() && !defaultVal.IsZero() {
-			newMap[key.String()] = fieldVal.Interface()
-			continue
-		}
-
 		fieldVal = reflect.ValueOf(fieldVal.Interface())
 		defaultVal = reflect.ValueOf(defaultVal.Interface())
 

--- a/pkg/dump/skip_defaults_test.go
+++ b/pkg/dump/skip_defaults_test.go
@@ -647,22 +647,6 @@ func TestCompareMaps(t *testing.T) {
 			},
 			expected: map[string]interface{}{},
 		},
-		{
-			name: "field has zero value for non-zero/not-defined defaults",
-			fieldMap: map[string]interface{}{
-				"host":       nil,
-				"jwk_arrays": []interface{}{},
-				"name":       "test",
-			},
-			defaultMap: map[string]interface{}{
-				"host": "localhost",
-			},
-			expected: map[string]interface{}{
-				"host":       nil,
-				"name":       "test",
-				"jwk_arrays": []interface{}{},
-			},
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Reverts Kong/go-database-reconciler#361

We need a revert for now. Some schema changes would be required
at gateway and konnect level for this functionality to work
properly for all versions.
More context on ticket: https://konghq.atlassian.net/browse/FTI-7110?focusedCommentId=186644
Slack thread: https://kongstrong.slack.com/archives/C02GZ0CGJNT/p1764750503779709