### PR TITLE
fix: fixed typo in entity name - basic-auth - to allow fetching schemas

### DIFF
--- a/pkg/dump/skip_defaults.go
+++ b/pkg/dump/skip_defaults.go
@@ -93,7 +93,7 @@ func removeDefaultsFromState(ctx context.Context, group *errgroup.Group,
 
 	// Basic Auth credentials
 	group.Go(func() error {
-		err := processStateEntities(state.BasicAuths, schemaFetcher, "basicauth_credential")
+		err := processStateEntities(state.BasicAuths, schemaFetcher, "basicauth_credentials")
 		if err != nil {
 			return fmt.Errorf("error removing defaults from basic auths: %w", err)
 		}


### PR DESCRIPTION
### Summary

When --skip-defaults was set and upstream had basic-auth credentials,
deck gateway dump was failing with error:

`Error: getting Kong state: reading configuration from Kong: error removing defaults from basic auths: error fetching schema for entity basicauth_credential of type basicauth_credential: HTTP status 404 (message: "No entity named 'basicauth_credential'")`

This is because the credential entity name was wrong (singular instead of plural).
This was getting an error from the API while retrieving schemas as the upstream 
didn't recognise the entity `basicauth_credential`. It recognised the plural version.

With the below typo fix, this issue shouldn't occur again.

Tests for this and other credential types are added here:
https://github.com/Kong/deck/pull/1889

### Issues resolved

For https://github.com/Kong/deck/issues/1839
FTI: https://konghq.atlassian.net/browse/FTI-7180

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
