### PR TITLE
feat: replace mockEnvVars bool with RenderEnvVarsMode in GetContentFromFiles

### DIFF
--- a/pkg/file/reader.go
+++ b/pkg/file/reader.go
@@ -33,14 +33,29 @@ type RenderConfig struct {
 // rooted at filename, read all the files with .yaml, .yml and .json extensions
 // and generate a content after a merge of the content from all the files.
 //
+// If mockEnvVars is true, environment variables are replaced with their names
+// instead of their values while rendering templates.
+//
 // It will return an error if the file representation is invalid
 // or if there is any error during processing.
 func GetContentFromFiles(filenames []string, mockEnvVars bool) (*Content, error) {
+	mode := EnvVarsExpand
+	if mockEnvVars {
+		mode = EnvVarsMock
+	}
+
+	return GetContentFromFilesWithEnvVars(filenames, mode)
+}
+
+// GetContentFromFilesWithEnvVars reads state files and allows callers to
+// control environment variable handling explicitly.
+// EnvVarsExpand expands variables, EnvVarsMock uses variable names as values,
+// and EnvVarsSkip skips template rendering entirely.
+func GetContentFromFilesWithEnvVars(filenames []string, mode RenderEnvVarsMode) (*Content, error) {
 	if len(filenames) == 0 {
 		return nil, ErrorFilenameEmpty
 	}
-
-	return getContent(filenames, mockEnvVars)
+	return getContent(filenames, mode)
 }
 
 // GetForKonnect processes the fileContent and renders a RawState and KonnectRawState

--- a/pkg/file/reader_test.go
+++ b/pkg/file/reader_test.go
@@ -69,7 +69,7 @@ func TestReadKongStateFromStdinFailsToParseText(t *testing.T) {
 
 	os.Stdin = tmpfile
 
-	c, err := GetContentFromFiles(filenames, false)
+	c, err := GetContentFromFilesWithEnvVars(filenames, EnvVarsExpand)
 	require.Error(t, err)
 	assert.Nil(c)
 }
@@ -98,7 +98,7 @@ func TestTransformNotFalse(t *testing.T) {
 
 	os.Stdin = tmpfile
 
-	c, err := GetContentFromFiles(filenames, false)
+	c, err := GetContentFromFilesWithEnvVars(filenames, EnvVarsExpand)
 	if err != nil {
 		panic(err)
 	}
@@ -140,7 +140,7 @@ func TestReadKongStateFromStdin(t *testing.T) {
 
 	os.Stdin = tmpfile
 
-	c, err := GetContentFromFiles(filenames, false)
+	c, err := GetContentFromFilesWithEnvVars(filenames, EnvVarsExpand)
 	assert.NotNil(c)
 	require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func TestReadKongStateFromFile(t *testing.T) {
 	filenames := []string{"testdata/config.yaml"}
 	require.Equal(t, "testdata/config.yaml", filenames[0])
 
-	c, err := GetContentFromFiles(filenames, false)
+	c, err := GetContentFromFilesWithEnvVars(filenames, EnvVarsExpand)
 	require.NotNil(t, c)
 	require.NoError(t, err)
 
@@ -166,4 +166,21 @@ func TestReadKongStateFromFile(t *testing.T) {
 			Enabled: kong.Bool(true),
 		}, c.Services[0].Service)
 	})
+}
+
+func TestGetContentFromFilesCompatibilityWrapper(t *testing.T) {
+	t.Setenv("DECK_SVC2_HOST", "2.example.com")
+	t.Setenv("DECK_FILE_LOG_FUNCTION", "return")
+
+	filenames := []string{"testdata/file.yaml"}
+
+	expanded, err := GetContentFromFiles(filenames, false)
+	require.NoError(t, err)
+	require.NotNil(t, expanded)
+	assert.Equal(t, "2.example.com", *expanded.Services[0].Host)
+
+	mocked, err := GetContentFromFiles(filenames, true)
+	require.NoError(t, err)
+	require.NotNil(t, mocked)
+	assert.Equal(t, "DECK_SVC2_HOST", *mocked.Services[0].Host)
 }

--- a/pkg/file/readfile.go
+++ b/pkg/file/readfile.go
@@ -16,7 +16,7 @@ import (
 // getContent reads all the YAML and JSON files in the directory or the
 // file, depending on the type of each item in filenames, merges the content of
 // these files and renders a Content.
-func getContent(filenames []string, mockEnvVars bool) (*Content, error) {
+func getContent(filenames []string, mode RenderEnvVarsMode) (*Content, error) {
 	var workspaces, runtimeGroups []string
 	var res Content
 	var errs []error
@@ -27,7 +27,7 @@ func getContent(filenames []string, mockEnvVars bool) (*Content, error) {
 		}
 
 		for filename, r := range readers {
-			content, err := readContent(r, mockEnvVars)
+			content, err := readContent(r, mode)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("reading file %s: %w", filename, err))
 				continue
@@ -108,13 +108,13 @@ func hasLeadingSpace(fileContent string) bool {
 
 // readContent reads all the byes until io.EOF and unmarshals the read
 // bytes into Content.
-func readContent(reader io.Reader, mockEnvVars bool) (*Content, error) {
+func readContent(reader io.Reader, mode RenderEnvVarsMode) (*Content, error) {
 	var err error
 	contentBytes, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
-	renderedContent, err := renderTemplate(string(contentBytes), mockEnvVars)
+	renderedContent, err := renderTemplate(string(contentBytes), mode)
 	if err != nil {
 		return nil, fmt.Errorf("parsing file: %w", err)
 	}

--- a/pkg/file/readfile_test.go
+++ b/pkg/file/readfile_test.go
@@ -634,7 +634,7 @@ kong.log.set_serialize_value("span_id", parse_traceid(ngx.ctx.KONG_SPANS[1].span
 			for k, v := range tt.envVars {
 				t.Setenv(k, v)
 			}
-			got, err := getContent(tt.args.filenames, false)
+			got, err := getContent(tt.args.filenames, EnvVarsExpand)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getContent() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/file/template.go
+++ b/pkg/file/template.go
@@ -9,6 +9,21 @@ import (
 	"text/template"
 )
 
+// RenderEnvVarsMode controls how environment variables are handled when
+// reading state files.
+type RenderEnvVarsMode int
+
+const (
+	// EnvVarsExpand expands environment variables present in the state file.
+	EnvVarsExpand RenderEnvVarsMode = iota
+	// EnvVarsMock replaces environment variable references with their names
+	// instead of their values. Useful for validation without real env vars.
+	EnvVarsMock
+	// EnvVarsSkip skips template rendering entirely, leaving the file content
+	// unchanged.
+	EnvVarsSkip
+)
+
 // default env var prefix, can be set using SetEnvVarPrefix
 var envVarPrefix = "DECK_"
 
@@ -75,9 +90,13 @@ func indent(spaces int, v string) string {
 	return strings.ReplaceAll(v, "\n", "\n"+pad)
 }
 
-func renderTemplate(content string, mockEnvVars bool) (string, error) {
+func renderTemplate(content string, mode RenderEnvVarsMode) (string, error) {
+	if mode == EnvVarsSkip {
+		return content, nil
+	}
+
 	var templateFuncs template.FuncMap
-	if mockEnvVars {
+	if mode == EnvVarsMock {
 		templateFuncs = template.FuncMap{
 			"env":     getPrefixedEnvVarMocked,
 			"toBool":  toBoolMocked,

--- a/pkg/file/template_test.go
+++ b/pkg/file/template_test.go
@@ -37,11 +37,11 @@ func Test_getPrefixedEnvVar(t *testing.T) {
 func Test_renderTemplate(t *testing.T) {
 	content := "Hello, ${{ env \"DECK_MY_VARIABLE\" }}!"
 	expectedOutput := "Hello, my_value!"
-	mockEnvVars := false
+	mode := EnvVarsExpand
 
 	os.Setenv("DECK_MY_VARIABLE", "my_value")
 
-	output, err := renderTemplate(content, mockEnvVars)
+	output, err := renderTemplate(content, mode)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -57,11 +57,11 @@ func Test_renderTemplateCustomPrefix(t *testing.T) {
 	SetEnvVarPrefix("PREFIX_")
 	content := "Hello, ${{ env \"PREFIX_MY_VARIABLE\" }}!"
 	expectedOutput := "Hello, my_value!"
-	mockEnvVars := false
+	mode := EnvVarsExpand
 
 	os.Setenv("PREFIX_MY_VARIABLE", "my_value")
 
-	output, err := renderTemplate(content, mockEnvVars)
+	output, err := renderTemplate(content, mode)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -78,11 +78,11 @@ func Test_renderTemplateIgnoresComments(t *testing.T) {
   # Also, ${{ env "DECK_NOT_SET_DOESNT_ERROR" }}!`
 
 	expectedOutput := `Hello, my_value!`
-	mockEnvVars := false
+	mode := EnvVarsExpand
 
 	os.Setenv("DECK_MY_VARIABLE", "my_value")
 
-	output, err := renderTemplate(content, mockEnvVars)
+	output, err := renderTemplate(content, mode)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -98,14 +98,62 @@ func Test_renderTemplateErrorWhenNotSet(t *testing.T) {
 Hello, ${{ env "DECK_MY_VARIABLE" }}!
 Also, ${{ env "DECK_NOT_SET_ERRORS" }}!`
 
-	mockEnvVars := false
+	mode := EnvVarsExpand
 
 	os.Setenv("DECK_MY_VARIABLE", "my_value")
 
-	_, err := renderTemplate(content, mockEnvVars)
+	_, err := renderTemplate(content, mode)
 	if err == nil {
 		t.Errorf("expected error but did not receive one")
 	}
 
 	os.Unsetenv("DECK_MY_VARIABLE")
+}
+
+func Test_renderTemplateMock(t *testing.T) {
+	content := `Hello, ${{ env "DECK_MY_VARIABLE" }}!`
+	// EnvVarsMock returns the variable name, not the value, and does not
+	// require the env var to be set.
+	expectedOutput := `Hello, DECK_MY_VARIABLE!`
+
+	output, err := renderTemplate(content, EnvVarsMock)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if output != expectedOutput {
+		t.Errorf("Expected output %q, but got %q", expectedOutput, output)
+	}
+}
+
+func Test_renderTemplateMockDoesNotRequireEnvVars(t *testing.T) {
+	// Even with an unset env var, EnvVarsMock should not error.
+	content := `Hello, ${{ env "DECK_NOT_SET" }}!`
+
+	_, err := renderTemplate(content, EnvVarsMock)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func Test_renderTemplateSkip(t *testing.T) {
+	// EnvVarsSkip returns the content unchanged, including template expressions.
+	content := `Hello, ${{ env "DECK_MY_VARIABLE" }}!`
+
+	output, err := renderTemplate(content, EnvVarsSkip)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if output != content {
+		t.Errorf("Expected output %q, but got %q", content, output)
+	}
+}
+
+func Test_renderTemplateSkipDoesNotRequireEnvVars(t *testing.T) {
+	// EnvVarsSkip must not error even when referenced env vars are not set.
+	content := `Hello, ${{ env "DECK_NOT_SET" }}!`
+
+	_, err := renderTemplate(content, EnvVarsSkip)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
 }

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -478,7 +478,7 @@ func stateFromFile(
 	currentState, err := state.NewKongState()
 	require.NoError(t, err, "stateFromFile: failed to build an initial empty KongState")
 
-	targetContent, err := file.GetContentFromFiles([]string{filename}, false)
+	targetContent, err := file.GetContentFromFilesWithEnvVars([]string{filename}, file.EnvVarsExpand)
 	require.NoErrorf(t, err, "failed to get file content from file %s", filename)
 
 	rawState, err := file.Get(ctx, targetContent, file.RenderConfig{
@@ -1397,7 +1397,7 @@ func renderYAMLFile(t *testing.T, inputPath string) string {
 	ctx := context.Background()
 
 	// Read and parse the input file
-	content, err := file.GetContentFromFiles([]string{inputPath}, false)
+	content, err := file.GetContentFromFilesWithEnvVars([]string{inputPath}, file.EnvVarsExpand)
 	require.NoError(t, err, "Failed to read input file: %s", inputPath)
 
 	// Create an empty current state


### PR DESCRIPTION
## Summary

Adds new`GetContentFromFilesWithEnvVars` method with a typed `RenderEnvVarsMode`, adding a new `EnvVarsSkip` mode that skips template rendering entirely.

## Changes

- Added `RenderEnvVarsMode` type with three constants to `pkg/file/template.go`:
  - `EnvVarsExpand` — expands env vars (replaces `false`)
  - `EnvVarsMock` — returns var names as values (replaces `true`)
  - `EnvVarsSkip` — skips template rendering entirely (new)
- Updated `GetContentFromFilesWithEnvVars`, `getContent`, `readContent`, and `renderTemplate` to use the new type
- Updated all callers in tests and integration tests

## Usage

```go
// Skip env var expansion entirely
content, err := file.GetContentFromFilesWithEnvVars(filenames, file.EnvVarsSkip)
```