### PR TITLE
fix: setting konnect flag before concurrent handling

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -473,6 +473,12 @@ func (sc *Syncer) Run(ctx context.Context, parallelism int, action Do) []error {
 
 	var wg sync.WaitGroup
 
+	// Set the Konnect flag before starting concurrent goroutines to avoid
+	// a data race.
+	if sc.isKonnect {
+		sc.kongClient.SetKonnectFlag(true)
+	}
+
 	sc.eventChan = make(chan crud.Event, eventBuffer)
 	sc.stopChan = make(chan struct{})
 	sc.errChan = make(chan error)
@@ -728,7 +734,6 @@ func (sc *Syncer) Solve(ctx context.Context, parallelism int, dry bool, isJSONOu
 
 		if sc.isKonnect {
 			workspaceExists, err = utils.KonnectWorkspaceExists(ctx, sc.kongClient)
-			sc.kongClient.SetKonnectFlag(true)
 		} else {
 			workspaceExists, err = utils.WorkspaceExists(ctx, sc.kongClient)
 		}


### PR DESCRIPTION
Note: This PR is successor of attached PR: https://github.com/Kong/go-database-reconciler/pull/428

### Summary
https://github.com/Kong/deck/actions/runs/24771118558/job/72477519286

This PR fixes a data race which we got on above run of apply test from decK.

The `SetKonnectFlag` flag was previously being accessed and modified across goroutines, which made it unsafe. To address this, `SetKonnectFlag` is now executed once upfront, before any goroutines are spawned.

Additionally, graphqlRateLimitingCostDecorationCRUD.Delete has been updated to rely on a precomputed isKonnect field instead of calling IsKonnectMode() at runtime. This brings it in line with how other CRUD implementations already handle the same logic, and avoids repeated access to shared state.


### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
