### PR TITLE
Add diagnostic message emitter

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -90,6 +90,9 @@ type Config struct {
 	// it is reused for schema fetching and caching (e.g. during SkipDefaults
 	// processing). When nil, a new registry is created internally.
 	SchemaRegistry *schema.Registry
+
+	// DiagnosticPolicy controls warning/error severity overrides.
+	DiagnosticPolicy utils.DiagnosticPolicy
 }
 
 func deduplicate(stringSlice []string) []string {

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -75,6 +75,7 @@ type stateBuilder struct {
 	isConsumerGroupPolicyOverrideSet bool
 
 	skipHashForBasicAuth bool
+	diagnosticPolicy     utils.DiagnosticPolicy
 	// Track consumer IDs to avoid duplicates in rawState
 	consumerIDsInRawState map[string]bool
 
@@ -1431,7 +1432,13 @@ func (b *stateBuilder) routes() {
 			}
 		}
 		if len(unsupportedRoutes) > 0 {
-			utils.PrintRouteRegexWarning(unsupportedRoutes)
+			if err := b.emitDiagnostic(
+				utils.DiagnosticCodeRouteRegexPathFormat,
+				utils.RouteRegexWarningMessage(unsupportedRoutes),
+			); err != nil {
+				b.err = err
+				return
+			}
 		}
 	}
 }
@@ -1773,7 +1780,7 @@ func (b *stateBuilder) validatePlugin(p FPlugin) error {
 			}
 		}
 		if consumerGroupsFound || enforceConsumerGroupsFound {
-			return utils.ErrorConsumerGroupUpgrade
+			return b.emitDiagnostic(utils.DiagnosticCodeRLAConsumerGroups, utils.ErrorConsumerGroupUpgrade.Error())
 		}
 	}
 	if p.Name != nil && *p.Name == openIDConnectPluginName {
@@ -1785,10 +1792,14 @@ func (b *stateBuilder) validatePlugin(p FPlugin) error {
 			}
 		}
 		if len(missingFields) > 0 {
-			return fmt.Errorf(
-				"openid-connect plugin requires explicit non-empty config values for %s "+
-					"to avoid regenerating session credentials during sync",
-				strings.Join(missingFields, ", "))
+			return b.emitDiagnostic(
+				utils.DiagnosticCodeOIDCMissingConfig,
+				fmt.Sprintf(
+					"openid-connect plugin requires explicit non-empty config values for %s "+
+						"to avoid regenerating session credentials during sync",
+					strings.Join(missingFields, ", "),
+				),
+			)
 		}
 	}
 	return nil

--- a/pkg/file/builder_test.go
+++ b/pkg/file/builder_test.go
@@ -4694,6 +4694,7 @@ func Test_stateBuilder_ConsumerGroupPolicyOverrides(t *testing.T) {
 	tests := []struct {
 		name                           string
 		isConsumerGroupPolicyOverrides bool
+		diagnosticPolicy               utils.DiagnosticPolicy
 		fields                         fields
 		want                           *utils.KongRawState
 		wantErr                        bool
@@ -4858,6 +4859,10 @@ func Test_stateBuilder_ConsumerGroupPolicyOverrides(t *testing.T) {
 		{
 			name:                           "consumer-group policy overrides set as false",
 			isConsumerGroupPolicyOverrides: false,
+			diagnosticPolicy: utils.NewDiagnosticPolicy(
+				[]utils.DiagnosticCode{utils.DiagnosticCodeRLAConsumerGroups},
+				nil,
+			),
 			fields: fields{
 				targetContent: &Content{
 					Info: &Info{
@@ -4948,6 +4953,7 @@ func Test_stateBuilder_ConsumerGroupPolicyOverrides(t *testing.T) {
 				currentState:                     tt.fields.currentState,
 				kongVersion:                      kong340Version,
 				isConsumerGroupPolicyOverrideSet: tt.isConsumerGroupPolicyOverrides,
+				diagnosticPolicy:                 tt.diagnosticPolicy,
 			}
 			d, _ := utils.GetDefaulter(ctx, defaulterTestOpts)
 			b.defaulter = d
@@ -4969,6 +4975,7 @@ func Test_stateBuilder_validateOpenIDConnectPlugin(t *testing.T) {
 	tests := []struct {
 		name       string
 		target     *Content
+		policy     utils.DiagnosticPolicy
 		wantErr    string
 		wantConfig kong.Configuration
 	}{
@@ -5023,15 +5030,35 @@ func Test_stateBuilder_validateOpenIDConnectPlugin(t *testing.T) {
 			},
 			wantErr: "openid-connect plugin requires explicit non-empty config values for cache_tokens_salt",
 		},
+		{
+			name:   "allows downgrade of required field validation to warning",
+			policy: utils.NewDiagnosticPolicy(nil, []utils.DiagnosticCode{utils.DiagnosticCodeOIDCMissingConfig}),
+			target: &Content{
+				Plugins: []FPlugin{
+					{
+						Plugin: kong.Plugin{
+							Name: kong.String("openid-connect"),
+							Config: kong.Configuration{
+								"cache_tokens_salt": "",
+							},
+						},
+					},
+				},
+			},
+			wantConfig: kong.Configuration{
+				"cache_tokens_salt": "",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &stateBuilder{
-				targetContent: tt.target,
-				currentState:  emptyState(),
-				kongVersion:   kong340Version,
-				skipDefaults:  true,
+				targetContent:    tt.target,
+				currentState:     emptyState(),
+				kongVersion:      kong340Version,
+				skipDefaults:     true,
+				diagnosticPolicy: tt.policy,
 			}
 
 			_, _, err := b.build()
@@ -5046,6 +5073,50 @@ func Test_stateBuilder_validateOpenIDConnectPlugin(t *testing.T) {
 			assert.Equal(t, tt.wantConfig, b.rawState.Plugins[0].Config)
 		})
 	}
+}
+
+func Test_stateBuilder_validateRateLimitingAdvancedDiagnosticSeverity(t *testing.T) {
+	testRand = rand.New(rand.NewSource(42))
+	target := &Content{
+		Plugins: []FPlugin{
+			{
+				Plugin: kong.Plugin{
+					Name: kong.String("rate-limiting-advanced"),
+					Config: kong.Configuration{
+						"consumer_groups":         []any{"foo-group"},
+						"enforce_consumer_groups": true,
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("defaults to error", func(t *testing.T) {
+		b := &stateBuilder{
+			targetContent: target,
+			currentState:  emptyState(),
+			kongVersion:   kong340Version,
+			skipDefaults:  true,
+		}
+
+		_, _, err := b.build()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, utils.ErrorConsumerGroupUpgrade.Error())
+	})
+
+	t.Run("allows downgrade to warning when configured", func(t *testing.T) {
+		b := &stateBuilder{
+			targetContent:    target,
+			currentState:     emptyState(),
+			kongVersion:      kong340Version,
+			skipDefaults:     true,
+			diagnosticPolicy: utils.NewDiagnosticPolicy(nil, []utils.DiagnosticCode{utils.DiagnosticCodeRLAConsumerGroups}),
+		}
+
+		_, _, err := b.build()
+		require.NoError(t, err)
+		require.Len(t, b.rawState.Plugins, 1)
+	})
 }
 
 func Test_stateBuilder_partials(t *testing.T) {

--- a/pkg/file/diagnostics.go
+++ b/pkg/file/diagnostics.go
@@ -1,0 +1,22 @@
+package file
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kong/go-database-reconciler/pkg/cprint"
+	"github.com/kong/go-database-reconciler/pkg/utils"
+)
+
+func (b *stateBuilder) emitDiagnostic(code utils.DiagnosticCode, msg string) error {
+	if b.diagnosticPolicy.ResolveSeverity(code) == utils.SeverityWarning {
+		cprint.UpdatePrintlnStdErr(msg)
+		return nil
+	}
+
+	if utils.DefaultSeverity(code) == utils.SeverityWarning {
+		return fmt.Errorf("warning (%s): %s", code, msg)
+	}
+
+	return errors.New(msg)
+}

--- a/pkg/file/diagnostics_test.go
+++ b/pkg/file/diagnostics_test.go
@@ -1,0 +1,41 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/kong/go-database-reconciler/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateBuilderEmitException(t *testing.T) {
+	t.Run("returns error when warning is configured as error", func(t *testing.T) {
+		b := &stateBuilder{
+			diagnosticPolicy: utils.NewDiagnosticPolicy([]utils.DiagnosticCode{utils.DiagnosticCodeRouteRegexPathFormat}, nil),
+		}
+
+		err := b.emitDiagnostic(utils.DiagnosticCodeRouteRegexPathFormat, "warning message")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "warning (route-regex-path-format)")
+	})
+
+	t.Run("prints warning when warning is not configured as error", func(t *testing.T) {
+		b := &stateBuilder{}
+		err := b.emitDiagnostic(utils.DiagnosticCodeRouteRegexPathFormat, "warning message")
+		require.NoError(t, err)
+	})
+	t.Run("returns error by default", func(t *testing.T) {
+		b := &stateBuilder{}
+		err := b.emitDiagnostic(utils.DiagnosticCodeOIDCMissingConfig, "validation message")
+		require.Error(t, err)
+		assert.EqualError(t, err, "validation message")
+	})
+
+	t.Run("downgrades to warning when configured", func(t *testing.T) {
+		b := &stateBuilder{
+			diagnosticPolicy: utils.NewDiagnosticPolicy(nil, []utils.DiagnosticCode{utils.DiagnosticCodeOIDCMissingConfig}),
+		}
+		err := b.emitDiagnostic(utils.DiagnosticCodeOIDCMissingConfig, "validation message")
+		require.NoError(t, err)
+	})
+}

--- a/pkg/file/reader.go
+++ b/pkg/file/reader.go
@@ -23,8 +23,9 @@ var (
 // RenderConfig contains necessary information to render a correct
 // KongConfig from a file.
 type RenderConfig struct {
-	CurrentState *state.KongState
-	KongVersion  semver.Version
+	CurrentState     *state.KongState
+	KongVersion      semver.Version
+	DiagnosticPolicy utils.DiagnosticPolicy
 }
 
 // GetContentFromFiles reads in a file with a slice of filenames and constructs
@@ -71,6 +72,7 @@ func GetForKonnect(ctx context.Context, fileContent *Content,
 	builder.ctx = ctx
 	builder.disableDynamicDefaults = true
 	builder.includeLicenses = false
+	builder.diagnosticPolicy = opt.DiagnosticPolicy
 
 	if fileContent.Transform != nil && !*fileContent.Transform {
 		return nil, nil, ErrorTransformFalseNotSupported
@@ -103,6 +105,7 @@ func Get(ctx context.Context, fileContent *Content, opt RenderConfig, dumpConfig
 	builder.skipHashForBasicAuth = dumpConfig.SkipHashForBasicAuth
 	builder.skipDefaults = dumpConfig.SkipDefaults
 	builder.schemaRegistry = dumpConfig.SchemaRegistry
+	builder.diagnosticPolicy = dumpConfig.DiagnosticPolicy
 
 	if len(dumpConfig.SelectorTags) > 0 {
 		builder.selectTags = dumpConfig.SelectorTags

--- a/pkg/utils/diagnostics.go
+++ b/pkg/utils/diagnostics.go
@@ -1,0 +1,152 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type DiagnosticCode string
+
+const (
+	DiagnosticCodeRouteRegexPathFormat DiagnosticCode = "route-regex-path-format"
+	DiagnosticCodeRLAConsumerGroups    DiagnosticCode = "rla-consumer-groups-deprecated"
+	DiagnosticCodeOIDCMissingConfig    DiagnosticCode = "oidc-missing-required-config"
+)
+
+var validDiagnosticCodes = map[DiagnosticCode]struct{}{
+	DiagnosticCodeRouteRegexPathFormat: {},
+	DiagnosticCodeRLAConsumerGroups:    {},
+	DiagnosticCodeOIDCMissingConfig:    {},
+}
+
+type Severity string
+
+const (
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+var defaultSeverityByDiagnosticCode = map[DiagnosticCode]Severity{
+	DiagnosticCodeRouteRegexPathFormat: SeverityWarning,
+	DiagnosticCodeRLAConsumerGroups:    SeverityError,
+	DiagnosticCodeOIDCMissingConfig:    SeverityError,
+}
+
+type DiagnosticPolicy struct {
+	AlwaysError   []DiagnosticCode
+	AlwaysWarning []DiagnosticCode
+}
+
+func NewDiagnosticPolicy(alwaysError, alwaysWarning []DiagnosticCode) DiagnosticPolicy {
+	return DiagnosticPolicy{
+		AlwaysError:   deduplicateDiagnosticCodes(alwaysError),
+		AlwaysWarning: deduplicateDiagnosticCodes(alwaysWarning),
+	}
+}
+
+func ParseDiagnosticCodes(value string) ([]DiagnosticCode, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(value, ",")
+	codes := make([]DiagnosticCode, 0, len(parts))
+	seen := map[DiagnosticCode]struct{}{}
+
+	for _, part := range parts {
+		normalized := DiagnosticCode(strings.TrimSpace(part))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := validDiagnosticCodes[normalized]; !ok {
+			return nil, fmt.Errorf("unknown diagnostic code: %s", normalized)
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		codes = append(codes, normalized)
+	}
+
+	return codes, nil
+}
+
+func ValidDiagnosticCodes() []DiagnosticCode {
+	codes := make([]DiagnosticCode, 0, len(validDiagnosticCodes))
+	for code := range validDiagnosticCodes {
+		codes = append(codes, code)
+	}
+	sort.Slice(codes, func(i, j int) bool {
+		return codes[i] < codes[j]
+	})
+	return codes
+}
+
+func ValidDiagnosticCodesString() string {
+	codes := ValidDiagnosticCodes()
+	if len(codes) == 0 {
+		return ""
+	}
+
+	stringCodes := make([]string, 0, len(codes))
+	for _, code := range codes {
+		stringCodes = append(stringCodes, string(code))
+	}
+
+	return strings.Join(stringCodes, ",")
+}
+
+func (p DiagnosticPolicy) IsAlwaysError(code DiagnosticCode) bool {
+	for _, c := range p.AlwaysError {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}
+
+func (p DiagnosticPolicy) IsAlwaysWarning(code DiagnosticCode) bool {
+	for _, c := range p.AlwaysWarning {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}
+
+func (p DiagnosticPolicy) ResolveSeverity(code DiagnosticCode) Severity {
+	if p.IsAlwaysError(code) {
+		return SeverityError
+	}
+	if p.IsAlwaysWarning(code) {
+		return SeverityWarning
+	}
+	if severity, ok := defaultSeverityByDiagnosticCode[code]; ok {
+		return severity
+	}
+	return SeverityWarning
+}
+
+func DefaultSeverity(code DiagnosticCode) Severity {
+	if severity, ok := defaultSeverityByDiagnosticCode[code]; ok {
+		return severity
+	}
+	return SeverityWarning
+}
+
+func deduplicateDiagnosticCodes(codes []DiagnosticCode) []DiagnosticCode {
+	if len(codes) == 0 {
+		return nil
+	}
+	seen := map[DiagnosticCode]struct{}{}
+	result := make([]DiagnosticCode, 0, len(codes))
+	for _, code := range codes {
+		if _, ok := seen[code]; ok {
+			continue
+		}
+		seen[code] = struct{}{}
+		result = append(result, code)
+	}
+	return result
+}

--- a/pkg/utils/diagnostics_test.go
+++ b/pkg/utils/diagnostics_test.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDiagnosticCodes(t *testing.T) {
+	t.Run("parses comma separated list", func(t *testing.T) {
+		codes, err := ParseDiagnosticCodes("route-regex-path-format")
+		require.NoError(t, err)
+		assert.Equal(t, []DiagnosticCode{DiagnosticCodeRouteRegexPathFormat}, codes)
+	})
+
+	t.Run("parses all supported warning codes", func(t *testing.T) {
+		codes, err := ParseDiagnosticCodes(
+			"route-regex-path-format,rla-consumer-groups-deprecated,oidc-missing-required-config",
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []DiagnosticCode{
+			DiagnosticCodeRouteRegexPathFormat,
+			DiagnosticCodeRLAConsumerGroups,
+			DiagnosticCodeOIDCMissingConfig,
+		}, codes)
+	})
+
+	t.Run("deduplicates values", func(t *testing.T) {
+		codes, err := ParseDiagnosticCodes(" route-regex-path-format,route-regex-path-format ")
+		require.NoError(t, err)
+		assert.Equal(t, []DiagnosticCode{DiagnosticCodeRouteRegexPathFormat}, codes)
+	})
+
+	t.Run("rejects unknown warning code", func(t *testing.T) {
+		_, err := ParseDiagnosticCodes("unknown-warning")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "unknown diagnostic code")
+	})
+}
+
+func TestDiagnosticPolicyIsAlwaysError(t *testing.T) {
+	policy := NewDiagnosticPolicy([]DiagnosticCode{DiagnosticCodeRouteRegexPathFormat}, nil)
+	assert.True(t, policy.IsAlwaysError(DiagnosticCodeRouteRegexPathFormat))
+	assert.False(t, policy.IsAlwaysError("different-warning"))
+}
+
+func TestDiagnosticPolicyResolveSeverity(t *testing.T) {
+	t.Run("uses default severity", func(t *testing.T) {
+		policy := NewDiagnosticPolicy(nil, nil)
+		assert.Equal(t, SeverityWarning, policy.ResolveSeverity(DiagnosticCodeRouteRegexPathFormat))
+		assert.Equal(t, SeverityError, policy.ResolveSeverity(DiagnosticCodeRLAConsumerGroups))
+		assert.Equal(t, SeverityError, policy.ResolveSeverity(DiagnosticCodeOIDCMissingConfig))
+	})
+
+	t.Run("always warning can downgrade default error", func(t *testing.T) {
+		policy := NewDiagnosticPolicy(nil, []DiagnosticCode{DiagnosticCodeOIDCMissingConfig})
+		assert.Equal(t, SeverityWarning, policy.ResolveSeverity(DiagnosticCodeOIDCMissingConfig))
+	})
+
+	t.Run("always error wins conflict", func(t *testing.T) {
+		policy := NewDiagnosticPolicy(
+			[]DiagnosticCode{DiagnosticCodeOIDCMissingConfig},
+			[]DiagnosticCode{DiagnosticCodeOIDCMissingConfig},
+		)
+		assert.Equal(t, SeverityError, policy.ResolveSeverity(DiagnosticCodeOIDCMissingConfig))
+	})
+}
+
+func TestValidDiagnosticCodesString(t *testing.T) {
+	assert.Equal(
+		t,
+		"oidc-missing-required-config,rla-consumer-groups-deprecated,route-regex-path-format",
+		ValidDiagnosticCodesString(),
+	)
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -249,16 +249,22 @@ func HasPathsWithRegex300AndAbove(route kong.Route) bool {
 
 // PrintRouteRegexWarning prints out a warning about 3.x routes' path usage.
 func PrintRouteRegexWarning(unsupportedRoutes []string) {
+	cprint.UpdatePrintlnStdErr(RouteRegexWarningMessage(unsupportedRoutes))
+}
+
+// RouteRegexWarningMessage returns the warning message for 3.x routes' path usage.
+func RouteRegexWarningMessage(unsupportedRoutes []string) string {
 	unsupportedRoutesLen := len(unsupportedRoutes)
 	// do not consider more than 10 sample routes to print out.
 	if unsupportedRoutesLen > 10 {
 		unsupportedRoutes = unsupportedRoutes[:10]
 	}
-	cprint.UpdatePrintfStdErr(
+	return fmt.Sprintf(
 		"%d unsupported routes' paths format with Kong version 3.0\n"+
 			"or above were detected. Some of these routes are (not an exhaustive list):\n\n"+
 			"%s\n\n"+UpgradeMessage,
-		unsupportedRoutesLen, strings.Join(unsupportedRoutes, "\n"),
+		unsupportedRoutesLen,
+		strings.Join(unsupportedRoutes, "\n"),
 	)
 }
 


### PR DESCRIPTION
### Summary

Add the ability for users to mark an error as a warning or a hard error (with a default value chosen by us). This allows us to make validations stricter while providing customers a way to undo the change.

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
