### PR TITLE
fix: Added check in maskEnvVar func for multiple data types

### DIFF
--- a/pkg/diff/diff_helpers.go
+++ b/pkg/diff/diff_helpers.go
@@ -211,21 +211,43 @@ var (
 )
 
 // MaskEnvVarValue masks DECK_ environment variable values in diff output.
-// Only exact, complete values are masked — never substrings within other values.
+// It identifies values in proper JSON/YAML positions (after `:` or as array elements)
+// and performs word-boundary substring replacement within those values. This prevents
+// corruption of non-value content (e.g., UUIDs in keys) while still masking secrets
+// that appear as part of larger strings.
 func MaskEnvVarValue(diffString string) string {
 	envVars := parseDeckEnvVars()
 	if len(envVars) == 0 {
 		return diffString
 	}
 
-	secrets := make(map[string]bool, len(envVars))
+	// Build sorted list of values (longest first) for substring replacement
+	var secrets []string
+	seen := make(map[string]bool, len(envVars))
 	for _, ev := range envVars {
-		if ev.Value != "" {
-			secrets[ev.Value] = true
+		if ev.Value != "" && !seen[ev.Value] {
+			secrets = append(secrets, ev.Value)
+			seen[ev.Value] = true
 		}
 	}
 	if len(secrets) == 0 {
 		return diffString
+	}
+	sort.Slice(secrets, func(i, j int) bool {
+		return len(secrets[i]) > len(secrets[j])
+	})
+
+	// Pre-compile word-boundary patterns once for all secrets
+	secretPatterns := make([]*regexp.Regexp, len(secrets))
+	for idx, secret := range secrets {
+		secretPatterns[idx] = regexp.MustCompile(`\b` + regexp.QuoteMeta(secret) + `\b`)
+	}
+
+	maskFn := func(s string) string {
+		for _, re := range secretPatterns {
+			s = re.ReplaceAllString(s, maskedValue)
+		}
+		return s
 	}
 
 	lines := strings.Split(diffString, "\n")
@@ -239,11 +261,12 @@ func MaskEnvVarValue(diffString string) string {
 			}
 			switch {
 			case sub[1] != "": // quoted string
-				if secrets[unescapeJSON(sub[1])] {
-					return match[:len(match)-len(`"`+sub[1]+`"`)] + `"` + maskedValue + `"`
+				masked := maskFn(sub[1])
+				if masked != sub[1] {
+					return match[:len(match)-len(`"`+sub[1]+`"`)] + `"` + masked + `"`
 				}
 			case sub[2] != "": // number
-				if secrets[sub[2]] {
+				if seen[sub[2]] {
 					prefix := match[:len(match)-len(sub[2])]
 					if isJSON {
 						return prefix + `"` + maskedValue + `"`
@@ -251,8 +274,9 @@ func MaskEnvVarValue(diffString string) string {
 					return prefix + maskedValue
 				}
 			case sub[3] != "": // YAML unquoted
-				if secrets[strings.TrimSpace(sub[3])] {
-					return match[:len(match)-len(sub[3])] + maskedValue
+				masked := maskFn(sub[3])
+				if masked != sub[3] {
+					return match[:len(match)-len(sub[3])] + masked
 				}
 			}
 			return match
@@ -262,25 +286,20 @@ func MaskEnvVarValue(diffString string) string {
 		if result == line {
 			result = arrayElemPattern.ReplaceAllStringFunc(line, func(match string) string {
 				sub := arrayElemPattern.FindStringSubmatch(match)
-				if sub == nil || !secrets[unescapeJSON(sub[2])] {
+				if sub == nil {
+					return match
+				}
+				masked := maskFn(sub[2])
+				if masked == sub[2] {
 					return match
 				}
 				quoted := `"` + sub[2] + `"`
 				suffix := match[len(sub[1])+len(quoted):]
-				return sub[1] + `"` + maskedValue + `"` + suffix
+				return sub[1] + `"` + masked + `"` + suffix
 			})
 		}
 
 		lines[i] = result
 	}
 	return strings.Join(lines, "\n")
-}
-
-// unescapeJSON decodes a raw JSON string body (content between quotes).
-func unescapeJSON(raw string) string {
-	var s string
-	if err := json.Unmarshal([]byte(`"`+raw+`"`), &s); err != nil {
-		return raw
-	}
-	return s
 }

--- a/pkg/diff/diff_helpers.go
+++ b/pkg/diff/diff_helpers.go
@@ -195,10 +195,15 @@ const maskedValue = "[masked]"
 
 // Compiled patterns for identifying values in diff output.
 var (
+	// jsonKeyPattern detects JSON-formatted output by matching a quoted key
+	// followed by a colon (e.g., "name":). This is how gojsondiff's ASCII
+	// formatter renders keys — YAML/plain text uses unquoted keys.
+	jsonKeyPattern = regexp.MustCompile(`"[^"]+"\s*:`)
+
 	// kvPattern matches values after a colon separator:
-	//   Group 1: quoted string  (:"val" or : "val")
-	//   Group 2: numeric        (: 42)
-	//   Group 3: YAML unquoted  (: bare-value)
+	//   Group 1: quoted string
+	//   Group 2: numeric
+	//   Group 3: YAML unquoted
 	kvPattern = regexp.MustCompile(
 		`:\s*"((?:[^"\\]|\\.)*)"|` +
 			`:\s+(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b|` +
@@ -210,11 +215,8 @@ var (
 	arrayElemPattern = regexp.MustCompile(`^([+\- ]*\s+)"((?:[^"\\]|\\.)*)"`)
 )
 
-// MaskEnvVarValue masks DECK_ environment variable values in diff output.
-// It identifies values in proper JSON/YAML positions (after `:` or as array elements)
-// and performs word-boundary substring replacement within those values. This prevents
-// corruption of non-value content (e.g., UUIDs in keys) while still masking secrets
-// that appear as part of larger strings.
+// MaskEnvVarValue masks DECK_ env var values in diff output using position-aware
+// regex and word-boundary matching to avoid corrupting unrelated content like UUIDs.
 func MaskEnvVarValue(diffString string) string {
 	envVars := parseDeckEnvVars()
 	if len(envVars) == 0 {
@@ -250,9 +252,14 @@ func MaskEnvVarValue(diffString string) string {
 		return s
 	}
 
+	// Detect format once: the diff engine (gojsondiff) always produces JSON-like
+	// output with quoted keys. Unified text diffs (from getDocumentDiff) never have
+	// quoted keys. We check the entire string rather than per-line to avoid false
+	// positives from YAML values that happen to contain `":`.
+	isJSON := jsonKeyPattern.MatchString(diffString)
+
 	lines := strings.Split(diffString, "\n")
 	for i, line := range lines {
-		isJSON := strings.Contains(line, `":`)
 
 		result := kvPattern.ReplaceAllStringFunc(line, func(match string) string {
 			sub := kvPattern.FindStringSubmatch(match)

--- a/pkg/diff/diff_helpers.go
+++ b/pkg/diff/diff_helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -190,9 +191,96 @@ func parseDeckEnvVars() []EnvVar {
 	return parsedEnvVars
 }
 
+const maskedValue = "[masked]"
+
+// Compiled patterns for identifying values in diff output.
+var (
+	// kvPattern matches values after a colon separator:
+	//   Group 1: quoted string  (:"val" or : "val")
+	//   Group 2: numeric        (: 42)
+	//   Group 3: YAML unquoted  (: bare-value)
+	kvPattern = regexp.MustCompile(
+		`:\s*"((?:[^"\\]|\\.)*)"|` +
+			`:\s+(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b|` +
+			`:\s+([^\s"\d{\[\]}\-][^\n,}\]]*)`,
+	)
+
+	// arrayElemPattern matches standalone quoted strings in JSON arrays
+	// (lines with only whitespace/diff markers before the value).
+	arrayElemPattern = regexp.MustCompile(`^([+\- ]*\s+)"((?:[^"\\]|\\.)*)"`)
+)
+
+// MaskEnvVarValue masks DECK_ environment variable values in diff output.
+// Only exact, complete values are masked — never substrings within other values.
 func MaskEnvVarValue(diffString string) string {
-	for _, envVar := range parseDeckEnvVars() {
-		diffString = strings.ReplaceAll(diffString, envVar.Value, "[masked]")
+	envVars := parseDeckEnvVars()
+	if len(envVars) == 0 {
+		return diffString
 	}
-	return diffString
+
+	secrets := make(map[string]bool, len(envVars))
+	for _, ev := range envVars {
+		if ev.Value != "" {
+			secrets[ev.Value] = true
+		}
+	}
+	if len(secrets) == 0 {
+		return diffString
+	}
+
+	lines := strings.Split(diffString, "\n")
+	for i, line := range lines {
+		isJSON := strings.Contains(line, `":`)
+
+		result := kvPattern.ReplaceAllStringFunc(line, func(match string) string {
+			sub := kvPattern.FindStringSubmatch(match)
+			if sub == nil {
+				return match
+			}
+			switch {
+			case sub[1] != "": // quoted string
+				if secrets[unescapeJSON(sub[1])] {
+					return match[:len(match)-len(`"`+sub[1]+`"`)] + `"` + maskedValue + `"`
+				}
+			case sub[2] != "": // number
+				if secrets[sub[2]] {
+					prefix := match[:len(match)-len(sub[2])]
+					if isJSON {
+						return prefix + `"` + maskedValue + `"`
+					}
+					return prefix + maskedValue
+				}
+			case sub[3] != "": // YAML unquoted
+				if secrets[strings.TrimSpace(sub[3])] {
+					return match[:len(match)-len(sub[3])] + maskedValue
+				}
+			}
+			return match
+		})
+
+		// Fall back to array element masking if no kv match was made.
+		if result == line {
+			result = arrayElemPattern.ReplaceAllStringFunc(line, func(match string) string {
+				sub := arrayElemPattern.FindStringSubmatch(match)
+				if sub == nil || !secrets[unescapeJSON(sub[2])] {
+					return match
+				}
+				quoted := `"` + sub[2] + `"`
+				suffix := match[len(sub[1])+len(quoted):]
+				return sub[1] + `"` + maskedValue + `"` + suffix
+			})
+		}
+
+		lines[i] = result
+	}
+	return strings.Join(lines, "\n")
+}
+
+// unescapeJSON decodes a raw JSON string body (content between quotes).
+func unescapeJSON(raw string) string {
+	var s string
+	if err := json.Unmarshal([]byte(`"`+raw+`"`), &s); err != nil {
+		return raw
+	}
+	return s
 }

--- a/pkg/diff/diff_helpers.go
+++ b/pkg/diff/diff_helpers.go
@@ -267,23 +267,24 @@ func MaskEnvVarValue(diffString string) string {
 				return match
 			}
 			switch {
-			case sub[1] != "": // quoted string
+			case sub[1] != "":
+				// Can't hardcode the prefix since `:\s*` matches both compact and formatted JSON,
+				// so the original spacing must be preserved.
 				masked := maskFn(sub[1])
 				if masked != sub[1] {
 					return match[:len(match)-len(`"`+sub[1]+`"`)] + `"` + masked + `"`
 				}
 			case sub[2] != "": // number
 				if seen[sub[2]] {
-					prefix := match[:len(match)-len(sub[2])]
 					if isJSON {
-						return prefix + `"` + maskedValue + `"`
+						return `: "` + maskedValue + `"`
 					}
-					return prefix + maskedValue
+					return ": " + maskedValue
 				}
 			case sub[3] != "": // YAML unquoted
 				masked := maskFn(sub[3])
 				if masked != sub[3] {
-					return match[:len(match)-len(sub[3])] + masked
+					return ": " + masked
 				}
 			}
 			return match

--- a/pkg/diff/diff_helpers_test.go
+++ b/pkg/diff/diff_helpers_test.go
@@ -154,13 +154,90 @@ func Test_MaskEnvVarsValues(t *testing.T) {
 		envVars map[string]string
 	}{
 		{
-			name: "JSON",
+			name: "JSON string values",
 			envVars: map[string]string{
 				"DECK_BAR": "barbar",
 				"DECK_BAZ": "bazbaz",
 			},
 			args: `{"foo":"foo","bar":"barbar","baz":"bazbaz"}`,
 			want: `{"foo":"foo","bar":"[masked]","baz":"[masked]"}`,
+		},
+		{
+			name: "JSON integer values produce valid JSON",
+			envVars: map[string]string{
+				"DECK_REDIS_DB":  "0",
+				"DECK_SYNC_RATE": "1",
+				"DECK_RETRIES":   "2",
+				"DECK_CACHE_EXP": "5",
+			},
+			args: `{"id": "b35b3ec2-fa1c-4f6c-825e-c38141562c76", "retries": 2, "redis_database": 0}`,
+			want: `{"id": "b35b3ec2-fa1c-4f6c-825e-c38141562c76", "retries": "[masked]", "redis_database": "[masked]"}`,
+		},
+		{
+			name: "short values do not corrupt UUIDs or substrings",
+			envVars: map[string]string{
+				"DECK_REDIS_DB": "0",
+			},
+			args: `{"id": "b35b3ec2-fa1c-4f6c-825e-c38141562c76", "name": "my-service-01", "port": 8000}`,
+			want: `{"id": "b35b3ec2-fa1c-4f6c-825e-c38141562c76", "name": "my-service-01", "port": 8000}`,
+		},
+		{
+			name: "diff format with markers",
+			envVars: map[string]string{
+				"DECK_SECRET": "mysecretvalue",
+			},
+			args: ` {
+   "name": "my-plugin",
+-  "config.secret": "mysecretvalue",
++  "config.secret": "newsecretvalue"
+ }`,
+			want: ` {
+   "name": "my-plugin",
+-  "config.secret": "[masked]",
++  "config.secret": "newsecretvalue"
+ }`,
+		},
+		{
+			name: "YAML unquoted values in unified diff",
+			envVars: map[string]string{
+				"DECK_SECRET":  "mysecretvalue",
+				"DECK_API_KEY": "sk-1234567890abcdef",
+			},
+			args: `--- old
++++ new
+@@ -1,4 +1,4 @@
+ name: my-service
+-secret: mysecretvalue
++secret: newsecretvalue
+ api_key: sk-1234567890abcdef
+ port: 8080`,
+			want: `--- old
++++ new
+@@ -1,4 +1,4 @@
+ name: my-service
+-secret: [masked]
++secret: newsecretvalue
+ api_key: [masked]
+ port: 8080`,
+		},
+		{
+			name: "YAML short numeric values do not corrupt other values",
+			envVars: map[string]string{
+				"DECK_REDIS_DB": "0",
+				"DECK_RETRIES":  "5",
+			},
+			args: `--- old
++++ new
+@@ -1,3 +1,3 @@
+ name: my-service-500
+ redis_database: 0
+ retries: 5`,
+			want: `--- old
++++ new
+@@ -1,3 +1,3 @@
+ name: my-service-500
+ redis_database: [masked]
+ retries: [masked]`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary

Fixes broken `DECK_` environment variable value masking that produced corrupted and invalid output:

1. Invalid JSON with `--json-output`: Masked integer values were inserted without quotes (e.g., "retries": [masked]), producing unparseable JSON output that broke downstream tooling.
2. Over-aggressive substring replacement: Short env var values like `DECK_REDIS_DB`=0 caused every occurrence of that character across the entire output to be replaced — corrupting UUIDs, ports, and timeouts, and inflating output file sizes.


### Issues resolved

Fix: https://github.com/Kong/deck/issues/2047
https://github.com/Kong/deck/issues/2063

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
