### PR TITLE
fix: avoid hang on invalid parallelism

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -472,7 +472,7 @@ func (sc *Syncer) wait() {
 // Run starts a diff and invokes action for every diff.
 func (sc *Syncer) Run(ctx context.Context, parallelism int, action Do) []error {
 	if parallelism < 1 {
-		return append([]error{}, fmt.Errorf("parallelism can not be negative"))
+		return append([]error{}, fmt.Errorf("parallelism can not be less than 1"))
 	}
 
 	var wg sync.WaitGroup
@@ -948,9 +948,11 @@ func (sc *Syncer) Solve(ctx context.Context, parallelism int, dry bool, isJSONOu
 
 		return result, nil
 	})
-	for event := range sc.eventChan {
-		// Add events remaining in the event queue but not dispatched to the runners to the dropped events.
-		sc.droppedEvents = append(sc.droppedEvents, event)
+	if sc.eventChan != nil {
+		for event := range sc.eventChan {
+			// Add events remaining in the event queue but not dispatched to the runners to the dropped events.
+			sc.droppedEvents = append(sc.droppedEvents, event)
+		}
 	}
 	// Output of dropped events due to errors.
 	for _, e := range sc.droppedEvents {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -1,0 +1,16 @@
+package diff
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolve_InvalidParallelism_Negative(t *testing.T) {
+	parallelism := -1
+	sc, _ := NewSyncer(SyncerOpts{})
+	_, errs, _ := sc.Solve(context.Background(), parallelism, true, false)
+	require.Len(t, errs, 1, "Solve should return exactly one error for parallelism=%d", parallelism)
+	require.EqualError(t, errs[0], "parallelism can not be less than 1")
+}


### PR DESCRIPTION
### Summary

When `Syncer.Solve` is called with a `parallelism` value less than 1, it would hang indefinitely. `Run` returns early on its `parallelism < 1` guard without ever allocating `sc.eventChan`, leaving it nil. `Solve` then ranged over that nil channel to drain dropped events, and a receive on a nil channel blocks forever — hanging deck until it times out.

By Adding a nil check on `sc.eventChan`, `Solve` return the error for an invalid `parallelism` value instead of deadlocking.

### Full changelog

* [Fix `Solve` hanging on a nil event channel when `parallelism < 1`]
* [Add unit tests covering `parallelism` of `-1`]

### Testing

- [x] Unit tests
- [x] Manual testing on local gateway
