### PR TITLE
fix: normalize empty arrays to nil for consistent comparison in config tree

### DIFF
--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -721,7 +721,6 @@ func sortNestedArraysBasedOnSchema(m map[string]any, schema gjson.Result) map[st
 	for k, v := range m {
 		switch value := v.(type) {
 		case []any:
-			// Normalize empty arrays to nil so an explicit `[]`
 			// Normalize empty arrays to nil so an explicit `[]` and an
 			// explicit nil value for the same key compare equal at every
 			// depth of the config tree. Note this does not equate `[]` with

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -722,7 +722,11 @@ func sortNestedArraysBasedOnSchema(m map[string]any, schema gjson.Result) map[st
 		switch value := v.(type) {
 		case []any:
 			// Normalize empty arrays to nil so an explicit `[]`
-			// and an absent/nil field compare equal at every depth of the config tree.
+			// Normalize empty arrays to nil so an explicit `[]` and an
+			// explicit nil value for the same key compare equal at every
+			// depth of the config tree. Note this does not equate `[]` with
+			// an absent key: a key that isn't present is never added to the
+			// map, so it stays distinct from an explicit empty array/nil.
 			if len(value) == 0 {
 				sortedMap[k] = nil
 				continue

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -721,6 +721,12 @@ func sortNestedArraysBasedOnSchema(m map[string]any, schema gjson.Result) map[st
 	for k, v := range m {
 		switch value := v.(type) {
 		case []any:
+			// Normalize empty arrays to nil so an explicit `[]` and an absent/nil field compare equal at every depth of the config tree.
+			if len(value) == 0 {
+				sortedMap[k] = nil
+				continue
+			}
+
 			currSchema := getSchemaForFieldName(schema, k)
 			// For list types like array or set, get the element schema
 			elementsSchema := currSchema.Get("elements")

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -721,7 +721,8 @@ func sortNestedArraysBasedOnSchema(m map[string]any, schema gjson.Result) map[st
 	for k, v := range m {
 		switch value := v.(type) {
 		case []any:
-			// Normalize empty arrays to nil so an explicit `[]` and an absent/nil field compare equal at every depth of the config tree.
+			// Normalize empty arrays to nil so an explicit `[]`
+			// and an absent/nil field compare equal at every depth of the config tree.
 			if len(value) == 0 {
 				sortedMap[k] = nil
 				continue

--- a/pkg/state/types_test.go
+++ b/pkg/state/types_test.go
@@ -720,6 +720,30 @@ func TestSortNestedArrays(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty array normalized to nil",
+			input: map[string]any{
+				testKey1: []any{},
+			},
+			expected: map[string]any{
+				testKey1: nil,
+			},
+		},
+		{
+			name: "empty array normalized to nil at nested depth",
+			input: map[string]any{
+				testKey1: []any{"b", "a"},
+				testKey2: map[string]any{
+					"nestedKey1": []any{},
+				},
+			},
+			expected: map[string]any{
+				testKey1: []any{"a", "b"},
+				testKey2: map[string]any{
+					"nestedKey1": nil,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -729,6 +753,29 @@ func TestSortNestedArrays(t *testing.T) {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestSortNestedArraysEmptyEqualsNil(t *testing.T) {
+	withEmptyArray := map[string]any{
+		testKey1: []any{},
+	}
+	withNilField := map[string]any{
+		testKey1: nil,
+	}
+	withoutField := map[string]any{}
+
+	sortedEmpty := sortNestedArraysBasedOnSchema(withEmptyArray, gjson.Result{})
+	sortedNil := sortNestedArraysBasedOnSchema(withNilField, gjson.Result{})
+	sortedAbsent := sortNestedArraysBasedOnSchema(withoutField, gjson.Result{})
+
+	if !reflect.DeepEqual(sortedEmpty, sortedNil) {
+		t.Errorf("expected empty array and nil field to normalize equally, got %v vs %v", sortedEmpty, sortedNil)
+	}
+
+	// Absent field is never added to the map, so it should not be treated as equal to an explicit nil/empty array.
+	if reflect.DeepEqual(sortedEmpty, sortedAbsent) {
+		t.Errorf("expected explicit empty array %v to differ from an absent field %v", sortedEmpty, sortedAbsent)
 	}
 }
 


### PR DESCRIPTION
### Summary

Fixed a perpetual diff where `deck diff` / `deck sync `never converged for any plugin config field set to an empty array (`[]`). One side of the comparison held `[]` while the other held nil/absent, so reflect.DeepEqual always reported a change and an update was queued on every run. Empty arrays are now normalized to `nil` at every depth of the config tree before comparison, so `[]` and an unset field compare equal and the diff reaches a clean `"no changes" `state.

### Full changelog

* [Fix] Perpetual diff issue for plugin config when an empty array is passed.

### Issues resolved

Fix: https://github.com/Kong/deck/issues/2175

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
