### PR TITLE
fix: preserve explicit nil config values when skipping schema defaults

### DIFF
--- a/pkg/dump/skip_defaults.go
+++ b/pkg/dump/skip_defaults.go
@@ -523,12 +523,21 @@ func compareMaps(fieldMap, defaultMap reflect.Value) any {
 			continue // Skip unexported fields
 		}
 
-		fieldVal = reflect.ValueOf(fieldVal.Interface())
-		defaultVal = reflect.ValueOf(defaultVal.Interface())
+		fieldIface := fieldVal.Interface()
+		defaultIface := defaultVal.Interface()
 
-		if !fieldVal.IsValid() || !defaultVal.IsValid() {
+		// An explicit null set by the user must be compared against the default,
+		// not discarded: reflect.ValueOf(nil) is an invalid Value with no Kind,
+		// so it has to be handled here before any Kind-based branching below.
+		if fieldIface == nil || defaultIface == nil {
+			if !compareValues(fieldIface, defaultIface) {
+				newMap[key.String()] = fieldIface
+			}
 			continue
 		}
+
+		fieldVal = reflect.ValueOf(fieldIface)
+		defaultVal = reflect.ValueOf(defaultIface)
 
 		if fieldVal.Kind() == reflect.Map && defaultVal.Kind() == reflect.Map {
 			nestedResult := compareMaps(fieldVal, defaultVal)

--- a/pkg/dump/skip_defaults_test.go
+++ b/pkg/dump/skip_defaults_test.go
@@ -655,6 +655,20 @@ func TestCompareMaps(t *testing.T) {
 			},
 			expected: map[string]any{},
 		},
+		{
+			name: "field explicitly set to nil differs from a non-nil default",
+			fieldMap: map[string]any{
+				fieldTimeout: 5000,
+				fieldName:    nil,
+			},
+			defaultMap: map[string]any{
+				fieldTimeout: 5000,
+				fieldName:    "default-host",
+			},
+			expected: map[string]any{
+				fieldName: nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Summary

This PR fixes the comparison so an explicit `null` is checked against the schema default like any other value, and kept in the output when it differs.


### Full changelog

* [Fix] `--skip-defaults` no longer drops plugin config fields explicitly set to
  `null` by the user when the field's schema default is non-null.

### Issues resolved

Fixes : https://github.com/Kong/deck/issues/1824


### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)
      <!-- likely N/A — this is a bugfix restoring documented behavior, not a new feature -->

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes