### PR TITLE
fix: update ai-model.alias to be optional

### DIFF
--- a/.github/workflows/integration-ai-gateway.yaml
+++ b/.github/workflows/integration-ai-gateway.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         kong_image:
-        - 'kong/kong-ai-gateway-dev:2.0.1-rc.2'
+        - 'kong/kong-ai-gateway-dev:2.0.2-rc.1'
     env:
       KONG_ANONYMOUS_REPORTS: "off"
       KONG_IMAGE: ${{ matrix.kong_image }}

--- a/.github/workflows/integration-ai-gateway.yaml
+++ b/.github/workflows/integration-ai-gateway.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         kong_image:
-        - 'kong/kong-ai-gateway-dev:2.0.2-rc.1'
+        - 'kong/kong-ai-gateway-dev:2.0.2-rc.2'
     env:
       KONG_ANONYMOUS_REPORTS: "off"
       KONG_IMAGE: ${{ matrix.kong_image }}

--- a/pkg/file/builder.go
+++ b/pkg/file/builder.go
@@ -1565,6 +1565,11 @@ func (b *stateBuilder) aiModels() {
 			am.CreatedAt = aiModel.CreatedAt
 		}
 
+		// AIModel.Alias defaults to AIModel.Name if not set, so we should set it to avoid drift
+		if utils.Empty(am.Alias) {
+			am.Alias = new(*am.Name)
+		}
+
 		utils.MustMergeTags(&am.AIModel, b.selectTags)
 
 		err = b.intermediate.AIModels.AddIgnoringDuplicates(state.AIModel{AIModel: am.AIModel})

--- a/pkg/file/codegen/main.go
+++ b/pkg/file/codegen/main.go
@@ -148,7 +148,7 @@ func main() {
 	schema.Definitions["FCustomPluginDefinition"].Required = []string{nameField, "schema", "handler"}
 
 	// AI model definitions
-	schema.Definitions["FAIModel"].Required = []string{nameField, "alias"}
+	schema.Definitions["FAIModel"].Required = []string{nameField}
 
 	// Foreign references
 	stringType := &jsonschema.Type{Type: "string"}

--- a/pkg/file/kong_json_schema.json
+++ b/pkg/file/kong_json_schema.json
@@ -427,7 +427,6 @@
     },
     "FAIModel": {
       "required": [
-        "alias",
         "name"
       ],
       "properties": {

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -11545,7 +11545,7 @@ func Test_Sync_AIModels(t *testing.T) {
 				AIModels: []*kong.AIModel{
 					{
 						Name:  kong.String("openai-gpt"),
-						Alias: kong.String("gpt-4o"),
+						Alias: kong.String("openai-gpt"), // input does not have alias, so alias is set to name
 						Tags:  kong.StringSlice("select-me", "tag1"),
 					},
 				},

--- a/tests/integration/testdata/sync/050-ai-models/kong-with-plugin.yaml
+++ b/tests/integration/testdata/sync/050-ai-models/kong-with-plugin.yaml
@@ -1,7 +1,6 @@
 _format_version: "3.0"
 ai_models:
 - name: openai-gpt
-  alias: gpt-4o
   tags:
   - tag1
   - select-me


### PR DESCRIPTION
### Summary
Two changes
1. For AI Model entity, `alias` was considered required in the previous images of AI Gateway, however it is not anymore. So we are treating it as optional again.
2. Updating CI to use the new image in test
3. AI Gateway defaults `ai_model.alias` to `ai_model.name` when not given - this is problematic for deck because it leads to drift - so we are mirroring the gateway behaviour ([the field has no meaning at the moment](https://kongstrong.slack.com/archives/C0BEBVDL5TL/p1786627937311069?thread_ts=1786625979.099269&cid=C0BEBVDL5TL) - but we will still keep it as gateway supports it)

### Testing

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
